### PR TITLE
fix(configure): remove example accounts, expand dashboard banner

### DIFF
--- a/config-template.json
+++ b/config-template.json
@@ -1,9 +1,6 @@
 {
   "__comment": "StratusScan Configuration Template - Copy this file to config.json and customize",
   "account_mappings": {
-    "123456789012": "PROD",
-    "234567890123": "DEV",
-    "345678901234": "TEST",
     "__comment": "Add your own account mappings in the format 'account_id': 'friendly_name'"
   },
   "agency_name": "YOUR-AGENCY",

--- a/config.json
+++ b/config.json
@@ -1,9 +1,6 @@
 {
   "__comment": "StratusScan Configuration Template - Copy this file to config.json and customize",
   "account_mappings": {
-    "123456789012": "PROD-ACCOUNT",
-    "234567890123": "DEV-ACCOUNT",
-    "345678901234": "TEST-ACCOUNT",
     "__comment": "Add your own account mappings in the format 'account_id': 'friendly_name'"
   },
   "organization_name": "YOUR-ORGANIZATION",

--- a/configure.py
+++ b/configure.py
@@ -410,8 +410,14 @@ def print_dashboard(config: Dict, config_path: Path):
     print("╔" + "═" * 68 + "╗")
 
     if identity:
+        mappings = config.get('account_mappings', {})
+        friendly = mappings.get(identity['account_id'], '—')
+        default_regions = config.get('default_regions', [])
+        region_str = ', '.join(default_regions) if default_regions else 'Not set'
         print_status_line("Environment", identity['partition_name'], 70)
-        print_status_line("Account", f"{identity['account_id']}", 70)
+        print_status_line("Account ID", identity['account_id'], 70)
+        print_status_line("Account Friendly", friendly, 70)
+        print_status_line("Region", region_str, 70)
     else:
         print_status_line("AWS Credentials", "❌ Not configured", 70)
 


### PR DESCRIPTION
Closes #164

## Summary

- Removed placeholder account IDs from `config-template.json` and `config.json` — they were valid 12-digit numbers so `validate_account_id()` passed them through, causing them to appear in account listings as if real
- Expanded `print_dashboard()` status box from 3 fields to 5: Environment, Account ID, Account Friendly (looks up `account_mappings`, shows `—` if unmapped), Region (joined `default_regions`), Configuration

## Test plan

- [ ] Run `python configure.py` — banner shows all 5 fields
- [ ] Manage Account Mappings shows 0 accounts (not 3 examples) on a fresh config
- [ ] Account Friendly shows `—` when the current account ID is not in mappings
- [ ] Account Friendly shows the mapped name after adding an account mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)