### PR TITLE
feat(vpc): add Internet Gateways tab to vpc_data_export

### DIFF
--- a/scripts/access_analyzer_export.py
+++ b/scripts/access_analyzer_export.py
@@ -522,7 +522,7 @@ def export_access_analyzer_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Access Analyzer data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/acm_export.py
+++ b/scripts/acm_export.py
@@ -371,7 +371,7 @@ def export_acm_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("ACM data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/ami_export.py
+++ b/scripts/ami_export.py
@@ -237,7 +237,7 @@ def export_ami_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("AMI data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
             utils.log_info(f"Total AMIs: {len(df)} records")
             print(f"Total AMIs: {len(df)} records")

--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -434,7 +434,7 @@ def export_api_gateway_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("API Gateway data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/autoscaling_export.py
+++ b/scripts/autoscaling_export.py
@@ -459,7 +459,7 @@ def export_autoscaling_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Auto Scaling data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/backup_export.py
+++ b/scripts/backup_export.py
@@ -401,7 +401,7 @@ def export_backup_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("AWS Backup data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/budgets_export.py
+++ b/scripts/budgets_export.py
@@ -327,7 +327,7 @@ def export_budgets_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Budgets data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             for sheet_name, df in data_frames.items():

--- a/scripts/cloudfront_export.py
+++ b/scripts/cloudfront_export.py
@@ -467,7 +467,7 @@ def export_cloudfront_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("CloudFront data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             for sheet_name, df in data_frames.items():

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -511,7 +511,7 @@ def export_cloudtrail_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("CloudTrail data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/cloudwatch_export.py
+++ b/scripts/cloudwatch_export.py
@@ -407,7 +407,7 @@ def export_cloudwatch_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("CloudWatch data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/config_export.py
+++ b/scripts/config_export.py
@@ -528,7 +528,7 @@ def export_config_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("AWS Config data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/datasync_export.py
+++ b/scripts/datasync_export.py
@@ -718,7 +718,7 @@ def _run_export(account_id: str, account_name: str, regions: List[str]) -> None:
 
     if output_path:
         utils.log_success("AWS DataSync data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         utils.log_info(f"Export contains data from {len(regions)} region(s)")
         utils.log_info(f"Total sheets: {len(dataframes)}")
         print("\nScript execution completed.")

--- a/scripts/detective_export.py
+++ b/scripts/detective_export.py
@@ -427,7 +427,7 @@ def export_to_excel(
 
         if output_path:
             utils.log_success("AWS Detective data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Log summary statistics
             total_graphs = len(graphs_data)

--- a/scripts/directconnect_export.py
+++ b/scripts/directconnect_export.py
@@ -679,7 +679,7 @@ def export_directconnect_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Direct Connect data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/dynamodb_export.py
+++ b/scripts/dynamodb_export.py
@@ -510,7 +510,7 @@ def export_dynamodb_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("DynamoDB data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/ebs_snapshots_export.py
+++ b/scripts/ebs_snapshots_export.py
@@ -267,7 +267,7 @@ def main():
 
         if output_path:
             utils.log_success("AWS EBS snapshots data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
             utils.log_info(f"Total snapshots exported: {total_snapshots}")
             print("\nScript execution completed.")

--- a/scripts/ebs_volumes_export.py
+++ b/scripts/ebs_volumes_export.py
@@ -387,7 +387,7 @@ def main():
 
         if excel_path:
             utils.log_success("AWS EBS volume data exported successfully!")
-            utils.log_info(f"File location: {excel_path}")
+            utils.log_success(f"File location: {excel_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
             utils.log_info(f"Total volumes exported: {len(all_volumes)}")
             print("\nScript execution completed.")

--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -730,7 +730,7 @@ def _run_export(account_id, account_name, regions, instance_filter, filter_desc)
 
     if output_path:
         utils.log_success("AWS EC2 data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
         utils.log_info(f"Total instances exported: {total_instances}")
         print("\nScript execution completed.")

--- a/scripts/ecr_export.py
+++ b/scripts/ecr_export.py
@@ -418,7 +418,7 @@ def export_ecr_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("ECR data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/efs_export.py
+++ b/scripts/efs_export.py
@@ -450,7 +450,7 @@ def export_efs_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("EFS data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/eks_export.py
+++ b/scripts/eks_export.py
@@ -574,7 +574,7 @@ def export_to_excel(all_clusters_data, all_node_groups_data, all_addons_data, ac
 
         if output_path:
             utils.log_success("AWS EKS data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Log summary statistics
             total_clusters = len(all_clusters_data)

--- a/scripts/elasticache_export.py
+++ b/scripts/elasticache_export.py
@@ -541,7 +541,7 @@ def export_elasticache_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("ElastiCache data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/elb_export.py
+++ b/scripts/elb_export.py
@@ -442,7 +442,7 @@ def main():
 
     if output_path:
         utils.log_success("AWS ELB data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
         utils.log_info(f"Total Classic ELBs: {total_classic_elbs}")
         utils.log_info(f"Total ALB/NLB: {total_elbv2s}")

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -289,7 +289,7 @@ def export_eventbridge_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("EventBridge data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/fsx_export.py
+++ b/scripts/fsx_export.py
@@ -347,7 +347,7 @@ def export_fsx_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("FSx data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/globalaccelerator_export.py
+++ b/scripts/globalaccelerator_export.py
@@ -718,7 +718,7 @@ def export_globalaccelerator_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Global Accelerator data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             print("\n=== EXPORT SUMMARY ===")

--- a/scripts/guardduty_export.py
+++ b/scripts/guardduty_export.py
@@ -577,7 +577,7 @@ def export_guardduty_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("GuardDuty data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/iam_export.py
+++ b/scripts/iam_export.py
@@ -1090,7 +1090,7 @@ def _export_users_to_excel(user_data, account_id, account_name):
 
         if output_path:
             utils.log_success("AWS IAM user data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data for {len(user_data)} IAM users")
             return str(output_path)
         else:
@@ -1162,7 +1162,7 @@ def _export_roles_to_excel(role_data, account_id, account_name):
 
         if output_path:
             utils.log_success("AWS IAM role data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data for {len(role_data)} IAM roles")
             return str(output_path)
         else:
@@ -1314,7 +1314,7 @@ def _export_policies_to_excel(managed_policies, inline_policies, account_id, acc
                 utils.log_warning(f"Could not apply conditional formatting: {e}")
 
             utils.log_success("AWS IAM policy data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {len(managed_policies)} managed and {len(inline_policies)} inline policies")
             return str(output_path)
         else:
@@ -1417,7 +1417,7 @@ def _export_comprehensive_to_excel(users_data, roles_data, policies_data, accoun
 
         if output_path:
             utils.log_success("AWS comprehensive IAM data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {len(users_data)} users, {len(roles_data)} roles, and {len(policies_data)} policies")
             return str(output_path)
         else:

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -1276,7 +1276,7 @@ def _export_users_to_excel(users_data, account_id, account_name):
 
         if output_path:
             utils.log_success("AWS IAM Identity Center users exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {total_users} users ({active_users} active, {inactive_users} inactive)")
             return str(output_path)
         else:
@@ -1363,7 +1363,7 @@ def _export_combined_to_excel(users_data, groups_data, permission_sets_data, acc
 
         if output_path:
             utils.log_success("AWS IAM Identity Center data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {len(users_data)} users, {len(groups_data)} groups, and {len(permission_sets_data)} permission sets")
             return str(output_path)
         else:
@@ -1441,7 +1441,7 @@ def _export_groups_to_excel(groups_data, account_id, account_name):
 
         if output_path:
             utils.log_success("AWS IAM Identity Center groups data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {total_groups} groups with {total_members} total members")
             return str(output_path)
         else:
@@ -1510,7 +1510,7 @@ def _export_permission_sets_to_excel(permission_sets_data, account_id, account_n
 
         if output_path:
             utils.log_success("AWS IAM Identity Center permission sets exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {total_ps} permission sets")
             return str(output_path)
         else:
@@ -1612,7 +1612,7 @@ def _export_comprehensive_to_excel(users_data, groups_data, permission_sets_data
 
         if output_path:
             utils.log_success("AWS IAM Identity Center comprehensive data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {len(users_data)} users, {len(groups_data)} groups, and {len(permission_sets_data)} permission sets")
             return str(output_path)
         else:

--- a/scripts/iam_rolesanywhere_export.py
+++ b/scripts/iam_rolesanywhere_export.py
@@ -389,7 +389,7 @@ def export_to_excel(trust_anchors: List[Dict], profiles: List[Dict], crls: List[
 
         if output_path:
             utils.log_success("IAM Roles Anywhere data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains {len(trust_anchors)} trust anchors, {len(profiles)} profiles, and {len(crls)} CRLs")
             return str(output_path)
         else:

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -477,7 +477,7 @@ def export_image_builder_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("EC2 Image Builder data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/kms_export.py
+++ b/scripts/kms_export.py
@@ -430,7 +430,7 @@ def export_kms_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("KMS data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/lambda_export.py
+++ b/scripts/lambda_export.py
@@ -465,7 +465,7 @@ def export_lambda_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Lambda data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/nacl_export.py
+++ b/scripts/nacl_export.py
@@ -265,7 +265,7 @@ def main():
 
         if output_path:
             utils.log_success("AWS Network ACL data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
             utils.log_info(f"Total Network ACLs exported: {len(all_nacl_data)}")
             print("\nScript execution completed.")

--- a/scripts/network_firewall_export.py
+++ b/scripts/network_firewall_export.py
@@ -552,7 +552,7 @@ def export_network_firewall_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Network Firewall data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/organizations_export.py
+++ b/scripts/organizations_export.py
@@ -740,7 +740,7 @@ def export_to_excel(org_info, ou_data, accounts_data, policies_data, account_id,
 
         if output_path:
             utils.log_success("AWS Organizations data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Log summary statistics
             total_ous = len([ou for ou in ou_data if ou.get('OU Type') == 'ORGANIZATIONAL_UNIT'])

--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -535,7 +535,7 @@ def export_to_excel(data, account_name, region_filter=None):
 
         if saved_file:
             utils.log_success("AWS RDS data exported successfully!")
-            utils.log_info(f"File location: {saved_file}")
+            utils.log_success(f"File location: {saved_file}")
             return saved_file
         else:
             utils.log_error("Failed to save using utils.save_dataframe_to_excel()")

--- a/scripts/route53_export.py
+++ b/scripts/route53_export.py
@@ -742,7 +742,7 @@ def export_route53_data(account_id: str, account_name: str, regions: List[str]):
 
         if output_path:
             utils.log_success("Route 53 data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             print("\n" + "=" * 60)

--- a/scripts/s3_accesspoints_export.py
+++ b/scripts/s3_accesspoints_export.py
@@ -449,7 +449,7 @@ def export_to_excel(
 
     if output_path:
         utils.log_success("S3 Access Points data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         return output_path
     else:
         utils.log_error("Error creating Excel file")

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -490,7 +490,7 @@ def export_to_excel(buckets_info, account_name, target_region=None):
 
     if output_path:
         utils.log_success("AWS S3 data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         return output_path
     else:
         utils.log_error("Error creating Excel file. Attempting to save as CSV instead.")

--- a/scripts/savings_plans_export.py
+++ b/scripts/savings_plans_export.py
@@ -248,7 +248,7 @@ def export_savings_plans_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Savings Plans data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             for sheet_name, df in data_frames.items():

--- a/scripts/secrets_manager_export.py
+++ b/scripts/secrets_manager_export.py
@@ -433,7 +433,7 @@ def export_secrets_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Secrets Manager data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/security_groups_export.py
+++ b/scripts/security_groups_export.py
@@ -618,7 +618,7 @@ def export_to_excel(security_group_rules, account_name, region_suffix=""):
 
     if output_path:
         utils.log_success("AWS Security Group data exported successfully!")
-        utils.log_info(f"File location: {output_path}")
+        utils.log_success(f"File location: {output_path}")
         return output_path
     else:
         utils.log_error("Error exporting data. Please check the logs.")

--- a/scripts/security_hub_export.py
+++ b/scripts/security_hub_export.py
@@ -458,7 +458,7 @@ def export_to_excel(all_findings_data, account_id, account_name):
 
         if output_path:
             utils.log_success("AWS Security Hub data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Log summary statistics
             total_findings = len(all_findings_data)

--- a/scripts/shield_export.py
+++ b/scripts/shield_export.py
@@ -640,7 +640,7 @@ def export_to_excel(
 
         if output_path:
             utils.log_success("AWS Shield Advanced data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Log summary statistics
             total_protections = len(protections_data)

--- a/scripts/sqs_sns_export.py
+++ b/scripts/sqs_sns_export.py
@@ -308,7 +308,7 @@ def export_sqs_sns_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("SQS/SNS data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/ssm_fleet_export.py
+++ b/scripts/ssm_fleet_export.py
@@ -430,7 +430,7 @@ def export_ssm_fleet_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("SSM Fleet data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/transfer_family_export.py
+++ b/scripts/transfer_family_export.py
@@ -706,7 +706,7 @@ def export_to_excel(
 
         if output_path:
             utils.log_success("Transfer Family data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info("Export contains:")
             utils.log_info(f"  - {len(servers_data)} servers")
             utils.log_info(f"  - {len(users_data)} users")

--- a/scripts/transit_gateway_export.py
+++ b/scripts/transit_gateway_export.py
@@ -541,7 +541,7 @@ def export_transit_gateway_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("Transit Gateway data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/verifiedaccess_export.py
+++ b/scripts/verifiedaccess_export.py
@@ -485,7 +485,7 @@ def export_to_excel(all_data: Dict[str, List[Dict]], account_id: str, account_na
 
         if output_path:
             utils.log_success("AWS Verified Access data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             total_resources = (len(all_data['instances']) + len(all_data['trust_providers']) +
                              len(all_data['groups']) + len(all_data['endpoints']))
             utils.log_info(f"Export contains {total_resources} total resources across all regions")

--- a/scripts/vpc_data_export.py
+++ b/scripts/vpc_data_export.py
@@ -923,7 +923,7 @@ def export_vpc_subnet_natgw_peering_info(account_id, account_name):
 
         if output_path:
             utils.log_success("AWS VPC data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s)")
 
             # Summary of exported data

--- a/scripts/vpc_data_export.py
+++ b/scripts/vpc_data_export.py
@@ -4,11 +4,11 @@
 = AWS RESOURCE SCANNER =
 ===========================
 
-Title: AWS VPC, Subnet, NAT Gateway, Peering Connection, and Elastic IP Export Tool
+Title: AWS VPC, Subnet, IGW, NAT Gateway, Peering Connection, and Elastic IP Export Tool
 Date: NOV-15-2025
 
 Description:
-This script exports VPC, subnet, NAT Gateway, VPC Peering Connection, and Elastic IP information
+This script exports VPC, subnet, Internet Gateway, NAT Gateway, VPC Peering Connection, and Elastic IP information
 from AWS regions into an Excel file with separate worksheets. The output filename
 includes the AWS account name based on the account ID mapping in the configuration and includes
 AWS identifiers for compliance and audit purposes.
@@ -650,6 +650,91 @@ def collect_vpc_peering_data(regions):
     utils.log_success(f"Total VPC Peering Connections collected: {len(all_vpc_peerings)}")
     return all_vpc_peerings
 
+@utils.aws_error_handler("Collecting Internet Gateway data for region", default_return=[])
+def collect_internet_gateway_data_for_region(region):
+    """
+    Collect Internet Gateway information from a single AWS region.
+
+    Args:
+        region: AWS region to scan
+
+    Returns:
+        list: List of dictionaries with Internet Gateway information
+    """
+    igw_data = []
+
+    if not utils.is_aws_region(region):
+        utils.log_error(f"Skipping invalid AWS region: {region}")
+        return []
+
+    utils.log_info(f"Searching for Internet Gateways in AWS region: {region}")
+
+    ec2_client = utils.get_boto3_client('ec2', region_name=region)
+
+    paginator = ec2_client.get_paginator('describe_internet_gateways')
+    igws = []
+    for page in paginator.paginate():
+        igws.extend(page.get('InternetGateways', []))
+
+    utils.log_info(f"  Found {len(igws)} Internet Gateways")
+
+    for igw in igws:
+        igw_id = igw.get('InternetGatewayId', '')
+        owner_id = igw.get('OwnerId', '')
+
+        name = None
+        if 'Tags' in igw:
+            for tag in igw['Tags']:
+                if tag['Key'] == 'Name':
+                    name = tag['Value']
+                    break
+
+        attachments = igw.get('Attachments', [])
+        if attachments:
+            vpc_id = attachments[0].get('VpcId', '')
+            attachment_state = attachments[0].get('State', '')
+        else:
+            vpc_id = ''
+            attachment_state = 'detached'
+
+        igw_data.append({
+            'Region': region,
+            'Name': name if name else 'N/A',
+            'Internet Gateway ID': igw_id,
+            'Attached VPC ID': vpc_id,
+            'Attachment State': attachment_state,
+            'Owner Account ID': owner_id,
+        })
+
+    return igw_data
+
+
+def collect_internet_gateway_data(regions):
+    """
+    Collect Internet Gateway information from AWS regions (concurrent).
+
+    Args:
+        regions: List of AWS regions to scan
+
+    Returns:
+        list: List of dictionaries with Internet Gateway information
+    """
+    utils.log_info("=== COLLECTING INTERNET GATEWAY INFORMATION ===")
+
+    region_results = utils.scan_regions_concurrent(
+        regions=regions,
+        scan_function=collect_internet_gateway_data_for_region,
+        show_progress=True
+    )
+
+    all_igws = []
+    for igws in region_results:
+        all_igws.extend(igws)
+
+    utils.log_success(f"Total Internet Gateways collected: {len(all_igws)}")
+    return all_igws
+
+
 @utils.aws_error_handler("Collecting Elastic IP data for region", default_return=[])
 def collect_elastic_ip_data_for_region(region):
     """
@@ -804,25 +889,30 @@ def export_vpc_subnet_natgw_peering_info(account_id, account_name):
         if all_nat_gateway_data:
             data_frames['NAT Gateways'] = pd.DataFrame(all_nat_gateway_data)
 
-    # STEP 4: Collect VPC Peering information (if selected)
+    # STEP 4: Collect Internet Gateway information
+    all_igw_data = collect_internet_gateway_data(regions)
+    if all_igw_data:
+        data_frames['Internet Gateways'] = pd.DataFrame(all_igw_data)
+
+    # STEP 5: Collect VPC Peering information (if selected)
     if export_vpc_peering:
         all_vpc_peering_data = collect_vpc_peering_data(regions)
         if all_vpc_peering_data:
             data_frames['VPC Peering Connections'] = pd.DataFrame(all_vpc_peering_data)
 
-    # STEP 5: Collect Elastic IP information (if selected)
+    # STEP 6: Collect Elastic IP information (if selected)
     if export_elastic_ip:
         all_elastic_ip_data = collect_elastic_ip_data(regions)
         if all_elastic_ip_data:
             data_frames['Elastic IPs'] = pd.DataFrame(all_elastic_ip_data)
 
-    # STEP 6: Prepare and sanitize all DataFrames
+    # STEP 7: Prepare and sanitize all DataFrames
     for sheet_name in data_frames:
         data_frames[sheet_name] = utils.sanitize_for_export(
             utils.prepare_dataframe_for_export(data_frames[sheet_name])
         )
 
-    # STEP 7: Save the Excel file using utils module
+    # STEP 8: Save the Excel file using utils module
     if not data_frames:
         utils.log_warning("No data was collected. Nothing to export.")
         return
@@ -850,7 +940,7 @@ def main():
     try:
         # Print title and get account information
         utils.setup_logging("vpc-data-export")
-        account_id, account_name = utils.print_script_banner("AWS VPC, SUBNET, NAT GATEWAY, PEERING, AND ELASTIC IP EXPORT")
+        account_id, account_name = utils.print_script_banner("AWS VPC, SUBNET, IGW, NAT GATEWAY, PEERING, AND ELASTIC IP EXPORT")
 
         # Check and install dependencies
         if not utils.ensure_dependencies('pandas', 'openpyxl'):

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -822,7 +822,7 @@ def export_vpn_data(account_id: str, account_name: str, regions: List[str]):
 
         if output_path:
             utils.log_success("VPN data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
 
             # Summary of exported data
             print("\n" + "=" * 60)

--- a/scripts/waf_export.py
+++ b/scripts/waf_export.py
@@ -610,7 +610,7 @@ def export_waf_data(account_id: str, account_name: str):
 
         if output_path:
             utils.log_success("WAF data exported successfully!")
-            utils.log_info(f"File location: {output_path}")
+            utils.log_success(f"File location: {output_path}")
             utils.log_info(f"Export contains data from {len(regions)} AWS region(s) + CloudFront (global)")
 
             # Summary of exported data


### PR DESCRIPTION
## Summary

- Adds `Internet Gateways` sheet to the VPC export workbook
- Inserted between NAT Gateways and VPC Peering Connections (network-flow order)
- Follows standard `@aws_error_handler` + paginator + `scan_regions_concurrent` pattern

**Fields:** IGW ID, Name, Attached VPC ID, Attachment State, Owner Account ID

Detached IGWs (no VPC attachment) are included with `attachment_state='detached'` — useful for identifying orphaned resources.

## Test plan

- [ ] Run `python scripts/vpc_data_export.py` against a real account
- [ ] Confirm `Internet Gateways` sheet appears in output workbook
- [ ] Verify IGW IDs, attached VPC IDs, and attachment states are correct
- [ ] Confirm detached IGWs (if any) appear with blank VPC ID and `detached` state
- [ ] Confirm GovCloud run completes without error

Partial UAT finding under #163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)