### PR TITLE
chore(rename): update all references from StratusScan-CLI to StratusScanCLI-AWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# StratusScan-CLI
+# StratusScanCLI-AWS
 
-[![Version: 0.4.0](https://img.shields.io/badge/version-0.4.0-blue.svg)](https://github.com/ColonelPanicX/StratusScan-CLI/releases)
+[![Version: 0.4.0](https://img.shields.io/badge/version-0.4.0-blue.svg)](https://github.com/ColonelPanicX/StratusScanCLI-AWS/releases)
 [![Status: Beta](https://img.shields.io/badge/status-beta-yellow.svg)](#project-status)
 [![Python 3.9+](https://img.shields.io/badge/python-3.9+-blue.svg)](https://www.python.org/downloads/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -17,8 +17,8 @@ A Python CLI tool for exporting AWS resource inventories to Excel workbooks. Sup
 
 ```bash
 # Clone the repository
-git clone https://github.com/ColonelPanicX/StratusScan-CLI.git
-cd StratusScan-CLI
+git clone https://github.com/ColonelPanicX/StratusScanCLI-AWS.git
+cd StratusScanCLI-AWS
 
 # Install dependencies
 pip install boto3 pandas openpyxl
@@ -369,8 +369,8 @@ export AWS_ACCESS_KEY_ID="..." AWS_SECRET_ACCESS_KEY="..."
 
 ```bash
 # Fork, clone, and install dev deps
-git clone https://github.com/yourusername/StratusScan-CLI.git
-cd StratusScan-CLI
+git clone https://github.com/yourusername/StratusScanCLI-AWS.git
+cd StratusScanCLI-AWS
 pip install -e ".[dev]"
 
 # Run tests
@@ -390,7 +390,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the exporter script template and cont
 
 **Current version: 0.4.0-beta**
 
-StratusScan-CLI is in active beta development. The API and output format may change before the 1.0.0 stable release. All active development occurs on the `dev` branch; `main` is release snapshots only.
+StratusScanCLI-AWS is in active beta development. The API and output format may change before the 1.0.0 stable release. All active development occurs on the `dev` branch; `main` is release snapshots only.
 
 ### What's new in v0.4.0
 
@@ -417,7 +417,7 @@ StratusScan-CLI is in active beta development. The API and output format may cha
 
 ## Versioning
 
-StratusScan-CLI uses [Semantic Versioning](https://semver.org/).
+StratusScanCLI-AWS uses [Semantic Versioning](https://semver.org/).
 
 | Series | Status | Notes |
 |---|---|---|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "stratusscan-cli"
+name = "stratusscancli-aws"
 version = "0.4.0-beta"
 description = "AWS defensive security scanning and auditing tool for resource exports"
 readme = "README.md"
@@ -80,10 +80,10 @@ stratusscan-configure = "configure:main"
 stratusscan-advanced = "advanced_settings:main"
 
 [project.urls]
-Homepage = "https://github.com/ColonelPanicX/StratusScan-CLI"
-Documentation = "https://github.com/ColonelPanicX/StratusScan-CLI#readme"
-Repository = "https://github.com/ColonelPanicX/StratusScan-CLI"
-Issues = "https://github.com/ColonelPanicX/StratusScan-CLI/issues"
+Homepage = "https://github.com/ColonelPanicX/StratusScanCLI-AWS"
+Documentation = "https://github.com/ColonelPanicX/StratusScanCLI-AWS#readme"
+Repository = "https://github.com/ColonelPanicX/StratusScanCLI-AWS"
+Issues = "https://github.com/ColonelPanicX/StratusScanCLI-AWS/issues"
 
 # ===== Tool Configuration =====
 

--- a/scripts/QUICKSTART-s3-accesspoints.md
+++ b/scripts/QUICKSTART-s3-accesspoints.md
@@ -11,7 +11,7 @@ Exports all S3 Access Points configurations from your AWS account:
 
 ```bash
 # Navigate to StratusScan directory
-cd /path/to/stratusscan-cli
+cd /path/to/stratusscancli-aws
 
 # Run the script
 python scripts/s3-accesspoints-export.py

--- a/scripts/README-s3-accesspoints-export.md
+++ b/scripts/README-s3-accesspoints-export.md
@@ -264,7 +264,7 @@ Could not get details for MRAP {name}: ...
 ## Output File Location
 
 ```
-/home/asimov/code/github/public/stratusscan-cli/output/{account-name}-s3-accesspoints-all-export-{MM.DD.YYYY}.xlsx
+/home/asimov/code/projects/stratusscancli-aws/output/{account-name}-s3-accesspoints-all-export-{MM.DD.YYYY}.xlsx
 ```
 
 ## Dependencies

--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -499,7 +499,7 @@ def validate_script_mappings(scripts_dir: Path = None) -> Dict[str, List[str]]:
 
     Args:
         scripts_dir: Path to the scripts directory. If None, resolves relative
-                     to this file's grandparent (i.e., stratusscan-cli/scripts/).
+                     to this file's grandparent (i.e., stratusscancli-aws/scripts/).
 
     Returns:
         Dict with keys 'missing' and 'found', each containing a list of

--- a/utils.py
+++ b/utils.py
@@ -57,7 +57,7 @@ _logging_configured = False
 def get_version() -> str:
     """Return the installed package version, or 'dev' if not installed."""
     try:
-        return _pkg_version("stratusscan-cli")
+        return _pkg_version("stratusscancli-aws")
     except PackageNotFoundError:
         return "dev"
 


### PR DESCRIPTION
## Summary

- Sweeps all references from `StratusScan-CLI` to `StratusScanCLI-AWS` across the codebase
- Covers: README.md, pyproject.toml, utils.py, CLAUDE.md, .collab/ docs, smart_scan scripts, and standalone script READMEs
- Deletes `transform_banners.py` (one-off migration script, no longer needed)

## Files changed
59 files — rename references only, no functional changes.

## Test plan
- [ ] Smoke test suite passes (`pytest tests/`)
- [ ] No functional code changed — rename-only sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)