### PR TITLE
refactor(utils): remove redundant print() calls from library code

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -1342,13 +1342,11 @@ def ensure_dependencies(*packages: str) -> bool:
     response = input("Would you like to install these packages now? (y/n): ").lower().strip()
 
     if response != 'y':
-        log_error("Cannot continue without required packages")
-        print("Exiting. Please install required packages manually with:")
-        print(f"  pip install {' '.join(missing)}")
+        log_error(f"Cannot continue without required packages. Run manually: pip install {' '.join(missing)}")
         return False
 
     # Install missing packages
-    print(f"Installing: {' '.join(missing)}")
+    log_warning(f"Installing: {' '.join(missing)}")
     try:
         subprocess.check_call(
             [sys.executable, "-m", "pip", "install"] + missing


### PR DESCRIPTION
Closes #171

## Summary

Removes the genuine `print()` violations from `utils.py`:

- **`ensure_dependencies()`**: replaced 2 prints in the error path with `log_error()` (already console-visible via WARNING+ threshold) and 1 print with `log_warning()`

## What was NOT changed (and why)

The remaining 34 `print()` calls in `utils.py` are intentional interactive UI code:
- `select_menu_option()`, `prompt_for_regions()`, confirmation prompts — these ARE the CLI menu layer (CLAUDE.md explicitly exempts "menu code")
- `run_script_with_spinner()` — terminal control characters (`\r`, `end=""`) require `print`; cannot be replaced with logger
- `print_script_banner()` — called by all 100+ exporters as their startup banner; explicitly named and intentional
- `log_success()` — console handler is WARNING+ only; the `print` is the only way success messages reach the terminal; removing it would make success messages invisible

The original motivation for #171 was TUI subprocess capture compatibility. TUI was cancelled (#125 closed won't-fix). Remaining prints serve their purpose.

## Test plan
- [x] `pytest tests/test_utils.py` — 43 passed, 1 pre-existing failure (unrelated account mapping test)
- [x] Pre-existing failure confirmed on `dev` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)