### PR TITLE
feat(exporters): add CLI argument support for non-interactive execution (#10)

### DIFF
--- a/scripts/access_analyzer_export.py
+++ b/scripts/access_analyzer_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export IAM Access Analyzer findings and analyzers to Excel")
 
 
 @utils.aws_error_handler("Collecting Access Analyzers from region", default_return=[])

--- a/scripts/acm_export.py
+++ b/scripts/acm_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Certificate Manager certificates to Excel")
 
 
 def scan_acm_certificates_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/acm_privateca_export.py
+++ b/scripts/acm_privateca_export.py
@@ -25,6 +25,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export ACM Private Certificate Authority resources to Excel")
 
 try:
     import pandas as pd

--- a/scripts/ami_export.py
+++ b/scripts/ami_export.py
@@ -49,6 +49,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Amazon Machine Images (AMIs) to Excel")
 
 
 @utils.aws_error_handler("Collecting AMIs from region", default_return=[])

--- a/scripts/api_gateway_export.py
+++ b/scripts/api_gateway_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS API Gateway REST and HTTP APIs to Excel")
 
 
 def scan_rest_apis_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/apprunner_export.py
+++ b/scripts/apprunner_export.py
@@ -28,6 +28,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS App Runner services to Excel")
 
 try:
     import pandas as pd

--- a/scripts/appsync_export.py
+++ b/scripts/appsync_export.py
@@ -29,6 +29,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS AppSync GraphQL APIs to Excel")
 
 try:
     import pandas as pd

--- a/scripts/autoscaling_export.py
+++ b/scripts/autoscaling_export.py
@@ -47,6 +47,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Auto Scaling Groups to Excel")
 
 
 @utils.aws_error_handler("Collecting Auto Scaling Groups", default_return=[])

--- a/scripts/backup_export.py
+++ b/scripts/backup_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Backup plans, vaults, and jobs to Excel")
 
 
 def _scan_backup_vaults_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/bedrock_export.py
+++ b/scripts/bedrock_export.py
@@ -26,6 +26,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Bedrock models and usage to Excel")
 
 try:
     import pandas as pd

--- a/scripts/billing_export.py
+++ b/scripts/billing_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS billing and cost data to Excel")
 
 # Setup logging
 logger = utils.setup_logging('billing-export')

--- a/scripts/budgets_export.py
+++ b/scripts/budgets_export.py
@@ -41,6 +41,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Budgets configuration to Excel")
 
 
 @utils.aws_error_handler("Collecting Budgets", default_return=[])

--- a/scripts/cloudformation_export.py
+++ b/scripts/cloudformation_export.py
@@ -40,6 +40,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export CloudFormation stacks and resources to Excel")
 
 @utils.aws_error_handler("Collecting CloudFormation stacks", default_return=[])
 def collect_stacks(region: str) -> List[Dict[str, Any]]:

--- a/scripts/cloudfront_export.py
+++ b/scripts/cloudfront_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export CloudFront distributions to Excel")
 
 
 @utils.aws_error_handler("Collecting CloudFront distributions", default_return=[])

--- a/scripts/cloudmap_export.py
+++ b/scripts/cloudmap_export.py
@@ -25,6 +25,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Cloud Map namespaces and services to Excel")
 
 try:
     import pandas as pd

--- a/scripts/cloudtrail_export.py
+++ b/scripts/cloudtrail_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export CloudTrail trails and event history to Excel")
 
 
 @utils.aws_error_handler("Collecting CloudTrail trails from region", default_return=[])

--- a/scripts/cloudwatch_export.py
+++ b/scripts/cloudwatch_export.py
@@ -40,6 +40,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export CloudWatch alarms and dashboards to Excel")
 
 
 def _scan_cloudwatch_alarms_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/codebuild_export.py
+++ b/scripts/codebuild_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export CodeBuild projects and builds to Excel")
 
 try:
     import pandas as pd

--- a/scripts/codecommit_export.py
+++ b/scripts/codecommit_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export CodeCommit repositories to Excel")
 
 try:
     import pandas as pd

--- a/scripts/codedeploy_export.py
+++ b/scripts/codedeploy_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export CodeDeploy applications and deployments to Excel")
 
 try:
     import pandas as pd

--- a/scripts/codepipeline_export.py
+++ b/scripts/codepipeline_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export CodePipeline pipelines to Excel")
 
 try:
     import pandas as pd

--- a/scripts/cognito_export.py
+++ b/scripts/cognito_export.py
@@ -25,6 +25,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Cognito user pools and identity pools to Excel")
 
 try:
     import pandas as pd

--- a/scripts/comprehend_export.py
+++ b/scripts/comprehend_export.py
@@ -26,6 +26,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Comprehend resources to Excel")
 
 try:
     import pandas as pd

--- a/scripts/compute_optimizer_export.py
+++ b/scripts/compute_optimizer_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Compute Optimizer recommendations to Excel")
 @utils.aws_error_handler("Getting available regions", default_return=[
     'us-east-1', 'us-east-2', 'us-west-1', 'us-west-2',
     'ca-central-1', 'eu-west-1', 'eu-west-2', 'eu-central-1',

--- a/scripts/compute_resources.py
+++ b/scripts/compute_resources.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     sys.path.append(str(Path(__file__).parent.parent))
     import utils
+args = utils.parse_script_args("Export all compute resources (EC2, EKS, ECS, Lambda, etc.) to Excel")
 
 utils.setup_logging('compute-resources')
 

--- a/scripts/config_export.py
+++ b/scripts/config_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Config rules, recorders, and compliance data to Excel")
 
 
 @utils.aws_error_handler("Collecting Config recorders from region", default_return=[])

--- a/scripts/connect_export.py
+++ b/scripts/connect_export.py
@@ -26,6 +26,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Connect instances and resources to Excel")
 
 try:
     import pandas as pd

--- a/scripts/controltower_export.py
+++ b/scripts/controltower_export.py
@@ -32,6 +32,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Control Tower landing zone configuration to Excel")
 
 try:
     import pandas as pd

--- a/scripts/cost_anomaly_detection_export.py
+++ b/scripts/cost_anomaly_detection_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Cost Anomaly Detection monitors and alerts to Excel")
 
 utils.setup_logging('cost-anomaly-detection-export')
 

--- a/scripts/cost_categories_export.py
+++ b/scripts/cost_categories_export.py
@@ -37,6 +37,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Cost Categories to Excel")
 
 utils.setup_logging('cost-categories-export')
 

--- a/scripts/cost_optimization_hub_export.py
+++ b/scripts/cost_optimization_hub_export.py
@@ -38,6 +38,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Cost Optimization Hub recommendations to Excel")
 
 utils.setup_logging("cost-optimization-hub-export")
 

--- a/scripts/database_resources.py
+++ b/scripts/database_resources.py
@@ -25,6 +25,7 @@ try:
 except ImportError:
     sys.path.append(str(Path(__file__).parent.parent))
     import utils
+args = utils.parse_script_args("Export all database resources (RDS, DynamoDB, etc.) to Excel")
 
 utils.setup_logging('database-resources')
 

--- a/scripts/datasync_export.py
+++ b/scripts/datasync_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS DataSync tasks and locations to Excel")
 
 utils.setup_logging('datasync-export')
 

--- a/scripts/detective_export.py
+++ b/scripts/detective_export.py
@@ -44,6 +44,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Detective graphs and findings to Excel")
 
 
 @utils.aws_error_handler("Collecting Detective graphs", default_return=[])

--- a/scripts/directconnect_export.py
+++ b/scripts/directconnect_export.py
@@ -49,6 +49,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Direct Connect connections and virtual interfaces to Excel")
 
 
 def _scan_connections_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/documentdb_export.py
+++ b/scripts/documentdb_export.py
@@ -29,6 +29,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon DocumentDB clusters to Excel")
 
 try:
     import pandas as pd

--- a/scripts/dynamodb_export.py
+++ b/scripts/dynamodb_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export DynamoDB tables and capacity to Excel")
 
 
 def scan_dynamodb_tables_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/ebs_snapshots_export.py
+++ b/scripts/ebs_snapshots_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EBS snapshots to Excel")
 
 def is_valid_aws_region(region_name):
     """

--- a/scripts/ebs_volumes_export.py
+++ b/scripts/ebs_volumes_export.py
@@ -53,6 +53,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EBS volumes to Excel")
 def is_valid_aws_region(region_name):
     """
     Check if a region name is a valid AWS region.

--- a/scripts/ec2_capacity_reservations_export.py
+++ b/scripts/ec2_capacity_reservations_export.py
@@ -37,6 +37,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export EC2 Capacity Reservations to Excel")
 
 utils.setup_logging('ec2-capacity-reservations-export')
 

--- a/scripts/ec2_dedicated_hosts_export.py
+++ b/scripts/ec2_dedicated_hosts_export.py
@@ -39,6 +39,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export EC2 Dedicated Hosts to Excel")
 
 utils.setup_logging('ec2-dedicated-hosts-export')
 

--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -51,6 +51,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EC2 instances to Excel")
 
 def get_os_info_from_ssm(instance_id, region):
     """

--- a/scripts/ecr_export.py
+++ b/scripts/ecr_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Elastic Container Registry repositories and images to Excel")
 
 
 def scan_ecr_repositories_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/ecs_export.py
+++ b/scripts/ecs_export.py
@@ -54,6 +54,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export ECS clusters, services, and tasks to Excel")
 @utils.aws_error_handler("Getting account information", default_return=("UNKNOWN", "UNKNOWN-ACCOUNT"))
 def get_account_info():
     """

--- a/scripts/efs_export.py
+++ b/scripts/efs_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Elastic File System volumes to Excel")
 
 
 def load_efs_pricing_data() -> Dict[str, float]:

--- a/scripts/eks_export.py
+++ b/scripts/eks_export.py
@@ -53,6 +53,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EKS clusters and node groups to Excel")
 @utils.aws_error_handler("Getting account information", default_return=("Unknown", "Unknown-AWS-Account"))
 def get_account_info():
     """

--- a/scripts/elasticache_export.py
+++ b/scripts/elasticache_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export ElastiCache clusters and replication groups to Excel")
 
 
 def load_elasticache_pricing_data(region: str = 'us-east-1') -> Dict[str, Any]:

--- a/scripts/elasticbeanstalk_export.py
+++ b/scripts/elasticbeanstalk_export.py
@@ -30,6 +30,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Elastic Beanstalk applications and environments to Excel")
 
 try:
     import pandas as pd

--- a/scripts/elb_export.py
+++ b/scripts/elb_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Elastic Load Balancers to Excel")
 
 def is_valid_aws_region(region_name):
     """

--- a/scripts/eventbridge_export.py
+++ b/scripts/eventbridge_export.py
@@ -40,6 +40,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EventBridge event buses and rules to Excel")
 
 
 def _scan_event_buses_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/fsx_export.py
+++ b/scripts/fsx_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Amazon FSx file systems to Excel")
 
 
 def _load_fsx_pricing() -> Dict[str, float]:

--- a/scripts/glacier_export.py
+++ b/scripts/glacier_export.py
@@ -27,6 +27,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export S3 Glacier vaults to Excel")
 
 try:
     import pandas as pd

--- a/scripts/globalaccelerator_export.py
+++ b/scripts/globalaccelerator_export.py
@@ -54,6 +54,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Global Accelerator accelerators to Excel")
 
 
 @utils.aws_error_handler("Collecting Global Accelerators", default_return=[])

--- a/scripts/glue_athena_export.py
+++ b/scripts/glue_athena_export.py
@@ -30,6 +30,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Glue and Athena resources to Excel")
 
 try:
     import pandas as pd

--- a/scripts/guardduty_export.py
+++ b/scripts/guardduty_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export GuardDuty detectors and findings to Excel")
 
 
 @utils.aws_error_handler("Collecting GuardDuty detectors from region", default_return=[])

--- a/scripts/health_export.py
+++ b/scripts/health_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Health events and affected entities to Excel")
 
 @utils.aws_error_handler("Collecting Health events", default_return=[])
 def collect_health_events(region: str, time_filter: Dict[str, Any]) -> List[Dict[str, Any]]:

--- a/scripts/iam_export.py
+++ b/scripts/iam_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export IAM users, roles, and policies to Excel")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export IAM Identity Center (SSO) configuration to Excel")
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/iam_identity_providers_export.py
+++ b/scripts/iam_identity_providers_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export IAM identity providers to Excel")
 
 try:
     import pandas as pd

--- a/scripts/iam_rolesanywhere_export.py
+++ b/scripts/iam_rolesanywhere_export.py
@@ -35,6 +35,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export IAM Roles Anywhere profiles and trust anchors to Excel")
 
 def format_tags(tags: List[Dict[str, str]]) -> str:
     """Format tags for display."""

--- a/scripts/image_builder_export.py
+++ b/scripts/image_builder_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EC2 Image Builder pipelines and recipes to Excel")
 
 
 @utils.aws_error_handler("Collecting Image Builder pipelines", default_return=[])

--- a/scripts/kms_export.py
+++ b/scripts/kms_export.py
@@ -42,6 +42,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export KMS keys and aliases to Excel")
 
 
 def scan_kms_keys_in_region(region: str, account_id: str) -> List[Dict[str, Any]]:

--- a/scripts/lakeformation_export.py
+++ b/scripts/lakeformation_export.py
@@ -28,6 +28,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Lake Formation resources and permissions to Excel")
 
 try:
     import pandas as pd

--- a/scripts/lambda_export.py
+++ b/scripts/lambda_export.py
@@ -48,6 +48,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Lambda functions to Excel")
 
 
 @utils.aws_error_handler("Collecting Lambda functions for region", default_return=[])

--- a/scripts/license_manager_export.py
+++ b/scripts/license_manager_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS License Manager configurations to Excel")
 
 @utils.aws_error_handler("Collecting license configurations", default_return=[])
 def collect_license_configurations(region: str) -> List[Dict[str, Any]]:

--- a/scripts/macie_export.py
+++ b/scripts/macie_export.py
@@ -33,6 +33,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Macie findings and configuration to Excel")
 
 try:
     import pandas as pd

--- a/scripts/marketplace_export.py
+++ b/scripts/marketplace_export.py
@@ -23,6 +23,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Marketplace subscriptions to Excel")
 
 try:
     import pandas as pd

--- a/scripts/nacl_export.py
+++ b/scripts/nacl_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Network ACLs to Excel")
 
 def is_valid_aws_region(region_name):
     """

--- a/scripts/neptune_export.py
+++ b/scripts/neptune_export.py
@@ -29,6 +29,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Neptune clusters to Excel")
 
 try:
     import pandas as pd

--- a/scripts/network_firewall_export.py
+++ b/scripts/network_firewall_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Network Firewall policies and rule groups to Excel")
 
 
 @utils.aws_error_handler("Collecting Network Firewalls from region", default_return=[])

--- a/scripts/network_manager_export.py
+++ b/scripts/network_manager_export.py
@@ -41,6 +41,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Network Manager global networks to Excel")
 
 utils.setup_logging('network-manager-export')
 

--- a/scripts/network_resources.py
+++ b/scripts/network_resources.py
@@ -32,6 +32,7 @@ try:
 except ImportError:
     sys.path.append(str(Path(__file__).parent.parent))
     import utils
+args = utils.parse_script_args("Export all network resources (VPC, subnets, NACLs, etc.) to Excel")
 
 utils.setup_logging('network-resources')
 

--- a/scripts/opensearch_export.py
+++ b/scripts/opensearch_export.py
@@ -30,6 +30,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon OpenSearch Service domains to Excel")
 
 try:
     import pandas as pd

--- a/scripts/organizations_export.py
+++ b/scripts/organizations_export.py
@@ -53,6 +53,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Organizations structure and SCPs to Excel")
 
 def convert_datetime_to_string(dt_obj):
     """

--- a/scripts/output_archive.py
+++ b/scripts/output_archive.py
@@ -31,6 +31,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Archive StratusScan output files into a zip")
 
 utils.setup_logging("output-archive")
 

--- a/scripts/rds_export.py
+++ b/scripts/rds_export.py
@@ -51,6 +51,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export RDS instances and clusters to Excel")
 
 # Dependency checking handled by utils.ensure_dependencies()
 def is_valid_aws_region(region_name):

--- a/scripts/redshift_export.py
+++ b/scripts/redshift_export.py
@@ -29,6 +29,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Redshift clusters to Excel")
 
 try:
     import pandas as pd

--- a/scripts/rekognition_export.py
+++ b/scripts/rekognition_export.py
@@ -24,6 +24,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Rekognition collections to Excel")
 
 try:
     import pandas as pd

--- a/scripts/reserved_instances_export.py
+++ b/scripts/reserved_instances_export.py
@@ -40,6 +40,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export EC2 Reserved Instances to Excel")
 
 utils.setup_logging('reserved-instances-export')
 

--- a/scripts/route53_export.py
+++ b/scripts/route53_export.py
@@ -47,6 +47,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Route 53 hosted zones and records to Excel")
 
 
 @utils.aws_error_handler("Collecting Route 53 hosted zones", default_return=[])

--- a/scripts/route_tables_export.py
+++ b/scripts/route_tables_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export VPC route tables to Excel")
 def get_all_regions():
     """Get list of all available AWS regions for the current partition."""
     try:

--- a/scripts/s3_accesspoints_export.py
+++ b/scripts/s3_accesspoints_export.py
@@ -32,6 +32,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export S3 access points to Excel")
 
 
 @utils.aws_error_handler("Collecting standard access points", default_return=[])

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -48,6 +48,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export S3 buckets inventory to Excel")
 
 def is_valid_aws_region(region_name):
     """

--- a/scripts/sagemaker_export.py
+++ b/scripts/sagemaker_export.py
@@ -27,6 +27,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon SageMaker resources to Excel")
 
 try:
     import pandas as pd

--- a/scripts/savings_plans_export.py
+++ b/scripts/savings_plans_export.py
@@ -43,6 +43,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS Savings Plans to Excel")
 
 
 @utils.aws_error_handler("Collecting Savings Plans", default_return=[])

--- a/scripts/secrets_manager_export.py
+++ b/scripts/secrets_manager_export.py
@@ -46,6 +46,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Secrets Manager secrets to Excel")
 
 
 def scan_secrets_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/security_groups_export.py
+++ b/scripts/security_groups_export.py
@@ -46,6 +46,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export EC2 security groups and rules to Excel")
 
 def is_valid_aws_region(region_name):
     """

--- a/scripts/security_hub_export.py
+++ b/scripts/security_hub_export.py
@@ -46,6 +46,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Security Hub findings and standards to Excel")
 
 # Setup logging
 logger = utils.setup_logging('security-hub-export')

--- a/scripts/service_catalog_export.py
+++ b/scripts/service_catalog_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Service Catalog portfolios and products to Excel")
 
 @utils.aws_error_handler("Listing portfolios", default_return=[])
 def list_portfolios(region: str) -> List[Dict[str, Any]]:

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -37,6 +37,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Discover AWS services in use and export inventory to Excel")
 
 # Setup logging
 logger = utils.setup_logging('services-in-use-export')

--- a/scripts/ses_export.py
+++ b/scripts/ses_export.py
@@ -26,6 +26,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon SES identities and configuration to Excel")
 
 # Setup logging
 logger = utils.setup_logging('ses-export')

--- a/scripts/ses_pinpoint_export.py
+++ b/scripts/ses_pinpoint_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon SES and Pinpoint resources to Excel")
 
 utils.setup_logging('ses-pinpoint-export')
 

--- a/scripts/shield_export.py
+++ b/scripts/shield_export.py
@@ -50,6 +50,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Shield Advanced protections to Excel")
 
 
 @utils.aws_error_handler("Checking Shield Advanced subscription", default_return=None)

--- a/scripts/sqs_sns_export.py
+++ b/scripts/sqs_sns_export.py
@@ -41,6 +41,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export SQS queues and SNS topics to Excel")
 
 
 def _scan_sqs_queues_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/ssm_fleet_export.py
+++ b/scripts/ssm_fleet_export.py
@@ -41,6 +41,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Systems Manager fleet and patch data to Excel")
 
 
 def _scan_managed_instances_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/stepfunctions_export.py
+++ b/scripts/stepfunctions_export.py
@@ -28,6 +28,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Step Functions state machines to Excel")
 
 try:
     import pandas as pd

--- a/scripts/storage_resources.py
+++ b/scripts/storage_resources.py
@@ -26,6 +26,7 @@ try:
 except ImportError:
     sys.path.append(str(Path(__file__).parent.parent))
     import utils
+args = utils.parse_script_args("Export all storage resources (S3, EFS, EBS, etc.) to Excel")
 
 utils.setup_logging('storage-resources')
 

--- a/scripts/storagegateway_export.py
+++ b/scripts/storagegateway_export.py
@@ -27,6 +27,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Storage Gateway resources to Excel")
 
 # Third-party imports (will be checked by dependency_check)
 import pandas as pd

--- a/scripts/transfer_family_export.py
+++ b/scripts/transfer_family_export.py
@@ -39,6 +39,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Transfer Family servers and users to Excel")
 
 def format_protocols(protocols: List[str]) -> str:
     """Format protocol list into a readable string."""

--- a/scripts/transit_gateway_export.py
+++ b/scripts/transit_gateway_export.py
@@ -44,6 +44,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Transit Gateways and attachments to Excel")
 
 
 def scan_transit_gateways_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/trusted_advisor_cost_optimization_export.py
+++ b/scripts/trusted_advisor_cost_optimization_export.py
@@ -37,6 +37,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export Trusted Advisor cost optimization checks to Excel")
 
 utils.setup_logging("trusted-advisor-cost-optimization-export")
 

--- a/scripts/verifiedaccess_export.py
+++ b/scripts/verifiedaccess_export.py
@@ -35,6 +35,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS Verified Access instances and groups to Excel")
 
 def format_tags(tags: List[Dict[str, str]]) -> str:
     """Format tags for display."""

--- a/scripts/verifiedpermissions_export.py
+++ b/scripts/verifiedpermissions_export.py
@@ -38,6 +38,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export Amazon Verified Permissions policy stores to Excel")
 
 utils.setup_logging('verifiedpermissions-export')
 

--- a/scripts/vpc_data_export.py
+++ b/scripts/vpc_data_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export VPCs, subnets, IGWs, NAT gateways, and Elastic IPs to Excel")
 
 @utils.aws_error_handler("Collecting VPC data for region", default_return=[])
 def collect_vpc_data_for_region(region):

--- a/scripts/vpn_export.py
+++ b/scripts/vpn_export.py
@@ -47,6 +47,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export VPN connections and customer gateways to Excel")
 
 
 def scan_vpn_connections_in_region(region: str) -> List[Dict[str, Any]]:

--- a/scripts/waf_export.py
+++ b/scripts/waf_export.py
@@ -45,6 +45,7 @@ except ImportError:
     except ImportError:
         print("ERROR: Could not import the utils module. Make sure utils.py is in the StratusScan directory.")
         sys.exit(1)
+args = utils.parse_script_args("Export AWS WAF web ACLs and rules to Excel")
 
 
 @utils.aws_error_handler("Collecting WAF web ACLs from region", default_return=[])

--- a/scripts/xray_export.py
+++ b/scripts/xray_export.py
@@ -26,6 +26,7 @@ except ImportError:
     else:
         sys.path.append(str(script_dir))
     import utils
+args = utils.parse_script_args("Export AWS X-Ray groups and sampling rules to Excel")
 
 try:
     import pandas as pd

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -431,3 +431,101 @@ class TestPromptConfirmation:
         monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
         result = utils.prompt_confirmation("Ready to export?")
         assert result == 'confirm'
+
+
+class TestParseScriptArgs:
+    """Tests for parse_script_args() and the _SCRIPT_ARGS module store."""
+
+    def _parse(self, argv: list, monkeypatch) -> "utils.argparse.Namespace":
+        """Helper: patch sys.argv, reset _SCRIPT_ARGS, and call parse_script_args."""
+        monkeypatch.setattr(sys, "argv", ["script.py"] + argv)
+        # Reset the global store before each parse so tests are independent
+        utils._SCRIPT_ARGS = None
+        return utils.parse_script_args("Test script description")
+
+    def test_single_region(self, monkeypatch):
+        args = self._parse(["--region", "us-east-1"], monkeypatch)
+        assert args.region == "us-east-1"
+        assert args.regions is None
+        assert args.all_regions is False
+
+    def test_multiple_regions(self, monkeypatch):
+        args = self._parse(["--regions", "us-east-1,us-west-2"], monkeypatch)
+        assert args.regions == "us-east-1,us-west-2"
+        region_list = [r.strip() for r in args.regions.split(",")]
+        assert len(region_list) == 2
+        assert "us-east-1" in region_list
+        assert "us-west-2" in region_list
+
+    def test_all_regions_flag(self, monkeypatch):
+        args = self._parse(["--all-regions"], monkeypatch)
+        assert args.all_regions is True
+        assert args.region is None
+        assert args.regions is None
+
+    def test_region_and_all_regions_mutually_exclusive(self, monkeypatch):
+        """--region and --all-regions together must raise SystemExit."""
+        monkeypatch.setattr(sys, "argv", ["script.py", "--region", "us-east-1", "--all-regions"])
+        utils._SCRIPT_ARGS = None
+        with pytest.raises(SystemExit):
+            utils.parse_script_args("Test script description")
+
+    def test_yes_flag(self, monkeypatch):
+        args = self._parse(["--yes"], monkeypatch)
+        assert args.yes is True
+
+    def test_yes_short_flag(self, monkeypatch):
+        args = self._parse(["-y"], monkeypatch)
+        assert args.yes is True
+
+    def test_profile(self, monkeypatch):
+        args = self._parse(["--profile", "my-profile"], monkeypatch)
+        assert args.profile == "my-profile"
+
+    def test_output_dir(self, monkeypatch):
+        args = self._parse(["--output-dir", "/tmp/test"], monkeypatch)
+        assert args.output_dir == "/tmp/test"
+
+    def test_defaults_when_no_args(self, monkeypatch):
+        args = self._parse([], monkeypatch)
+        assert args.region is None
+        assert args.regions is None
+        assert args.all_regions is False
+        assert args.yes is False
+        assert args.profile is None
+        assert args.output_dir == "output"
+
+    def test_sets_module_global(self, monkeypatch):
+        """parse_script_args() must populate utils._SCRIPT_ARGS."""
+        utils._SCRIPT_ARGS = None
+        args = self._parse(["--region", "eu-west-1"], monkeypatch)
+        assert utils._SCRIPT_ARGS is not None
+        assert utils._SCRIPT_ARGS.region == "eu-west-1"
+        assert utils.get_script_args() is utils._SCRIPT_ARGS
+
+    def test_get_script_args_returns_none_before_parse(self):
+        """get_script_args() returns None when parse_script_args() has not run."""
+        utils._SCRIPT_ARGS = None
+        assert utils.get_script_args() is None
+
+    def test_prompt_region_selection_respects_region_flag(self, monkeypatch):
+        """prompt_region_selection() must return single-item list when --region set."""
+        args = self._parse(["--region", "ap-southeast-1"], monkeypatch)
+        result = utils.prompt_region_selection()
+        assert result == ["ap-southeast-1"]
+
+    def test_prompt_region_selection_respects_regions_flag(self, monkeypatch):
+        """prompt_region_selection() must return list when --regions set."""
+        args = self._parse(["--regions", "us-east-1,eu-west-1"], monkeypatch)
+        result = utils.prompt_region_selection()
+        assert result == ["us-east-1", "eu-west-1"]
+
+    def test_prompt_for_confirmation_respects_yes_flag(self, monkeypatch):
+        """prompt_for_confirmation() must return True when --yes set."""
+        self._parse(["--yes"], monkeypatch)
+        result = utils.prompt_for_confirmation("Continue?")
+        assert result is True
+
+    def teardown_method(self, method):
+        """Reset _SCRIPT_ARGS after each test to avoid cross-test contamination."""
+        utils._SCRIPT_ARGS = None

--- a/utils.py
+++ b/utils.py
@@ -59,6 +59,17 @@ logger = None
 # Tracks whether setup_logging() has been explicitly called
 _logging_configured = False
 
+# ---------------------------------------------------------------------------
+# Script args store — populated by parse_script_args() at script start
+# ---------------------------------------------------------------------------
+
+_SCRIPT_ARGS: Optional["argparse.Namespace"] = None
+
+
+def get_script_args() -> Optional["argparse.Namespace"]:
+    """Return the parsed script args namespace, or None if not yet parsed."""
+    return _SCRIPT_ARGS
+
 
 # ---------------------------------------------------------------------------
 # Navigation signals — raised by prompt_menu() for b / x input
@@ -299,6 +310,16 @@ def prompt_region_selection(
             return auto_regions
         _partition = detect_partition()
         return get_partition_regions(_partition, all_regions=True)
+
+    # CLI flag override — takes precedence over interactive prompts
+    if _SCRIPT_ARGS is not None:
+        if _SCRIPT_ARGS.region:
+            return [_SCRIPT_ARGS.region]
+        if _SCRIPT_ARGS.regions:
+            return [r.strip() for r in _SCRIPT_ARGS.regions.split(",") if r.strip()]
+        if _SCRIPT_ARGS.all_regions:
+            _partition = detect_partition()
+            return get_partition_regions(_partition, all_regions=True)
 
     partition = detect_partition()
     default_regions = get_default_regions()
@@ -654,6 +675,10 @@ def prompt_for_confirmation(message: str = "Do you want to continue?", default: 
     if is_auto_run():
         return default
 
+    # CLI flag override — --yes / -y skips confirmation
+    if _SCRIPT_ARGS is not None and _SCRIPT_ARGS.yes:
+        return True
+
     # TODO: Issue #C — add b/x navigation support here
     default_prompt = " (Y/n): " if default else " (y/N): "
     response = input(f"{message}{default_prompt}").strip().lower()
@@ -792,18 +817,23 @@ def get_output_dir() -> Path:
     """
     Get the path to the output directory and create it if it doesn't exist.
 
+    Resolution order:
+      1. ``_SCRIPT_ARGS.output_dir`` set by ``parse_script_args()`` (absolute
+         path is used as-is; relative path is resolved from CWD)
+      2. ``output/`` subdirectory of the StratusScan project root
+
     Returns:
-        Path: Path to the output directory
+        Path: Path to the output directory (guaranteed to exist)
     """
-    # Get StratusScan root directory
-    root_dir = get_stratusscan_root()
+    if _SCRIPT_ARGS is not None and _SCRIPT_ARGS.output_dir != "output":
+        output_dir = Path(_SCRIPT_ARGS.output_dir)
+        if not output_dir.is_absolute():
+            output_dir = Path.cwd() / output_dir
+    else:
+        root_dir = get_stratusscan_root()
+        output_dir = root_dir / "output"
 
-    # Define the output directory path
-    output_dir = root_dir / "output"
-
-    # Create the directory if it doesn't exist
-    output_dir.mkdir(exist_ok=True)
-
+    output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 
 def get_output_filepath(filename: str) -> Path:
@@ -2542,6 +2572,70 @@ def get_auto_regions() -> Optional[List[str]]:
     return [r.strip() for r in val.split(",") if r.strip()] if val else None
 
 
+def parse_script_args(script_description: str) -> "argparse.Namespace":
+    """
+    Parse standard CLI arguments for an exporter script.
+
+    Must be called at the top of each exporter script (after ``import utils``)
+    to populate the module-level ``_SCRIPT_ARGS`` store.  Subsequent calls to
+    ``prompt_region_selection()``, ``prompt_for_confirmation()``,
+    ``get_aws_session()``, and ``create_export_filename()`` read from this
+    store automatically — no per-script wiring required.
+
+    Uses ``parse_known_args()`` so that pytest's own argv does not cause
+    errors when test files import exporter modules.
+
+    Args:
+        script_description: One-line description shown in ``--help`` output.
+
+    Returns:
+        argparse.Namespace with attributes:
+            region, regions, all_regions, profile, output_dir, yes
+    """
+    import argparse  # lazy import — keeps argparse out of the global namespace
+
+    global _SCRIPT_ARGS
+
+    parser = argparse.ArgumentParser(description=script_description)
+
+    region_group = parser.add_mutually_exclusive_group()
+    region_group.add_argument(
+        "--region",
+        help="Single AWS region to scan (e.g. us-east-1)",
+    )
+    region_group.add_argument(
+        "--regions",
+        help="Comma-separated list of AWS regions to scan (e.g. us-east-1,us-west-2)",
+    )
+    region_group.add_argument(
+        "--all-regions",
+        action="store_true",
+        dest="all_regions",
+        help="Scan all available regions for the detected partition",
+    )
+
+    parser.add_argument(
+        "--profile",
+        help="AWS named profile to use for authentication",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="output",
+        dest="output_dir",
+        help="Output directory for exported files (default: output/)",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Skip confirmation prompts (non-interactive mode)",
+    )
+
+    args, _ = parser.parse_known_args()
+    _SCRIPT_ARGS = args
+    return args
+
+
 # ---------------------------------------------------------------------------
 # Region validation
 # ---------------------------------------------------------------------------
@@ -2653,17 +2747,27 @@ def detect_partition(region_name: Optional[str] = None) -> str:
 # ---------------------------------------------------------------------------
 
 
-def get_aws_session(region_name: Optional[str] = None) -> boto3.Session:
+def get_aws_session(
+    region_name: Optional[str] = None,
+    profile_name: Optional[str] = None,
+) -> boto3.Session:
     """
     Create a boto3 session for the specified region.
 
+    Profile resolution order:
+      1. ``profile_name`` argument (explicit caller override)
+      2. ``_SCRIPT_ARGS.profile`` set by ``parse_script_args()``
+      3. boto3 default (AWS_PROFILE env var, ~/.aws/config default)
+
     Args:
         region_name: AWS region (None = default from config)
+        profile_name: AWS named profile (None = use CLI arg or boto3 default)
 
     Returns:
         boto3.Session: Configured session
     """
-    return boto3.Session(region_name=region_name)
+    profile = profile_name or (_SCRIPT_ARGS.profile if _SCRIPT_ARGS else None)
+    return boto3.Session(region_name=region_name, profile_name=profile)
 
 
 def get_boto3_client(service: str, region_name: Optional[str] = None, **kwargs) -> BaseClient:


### PR DESCRIPTION
## Summary

Closes #10

- Adds `parse_script_args(description)` to `utils.py` with standard flags: `--region`, `--regions`, `--all-regions`, `--profile`, `--output-dir`, `--yes`/`-y`
- All 107 scripts in `scripts/` (excluding `smart_scan/`) call `utils.parse_script_args()` immediately after `import utils`, registering their args at module load time
- `prompt_region_selection()`, `prompt_for_confirmation()`, `get_aws_session()`, and `get_output_dir()` read from `_SCRIPT_ARGS` automatically — no per-script wiring beyond the one-line call
- `STRATUSSCAN_AUTO_RUN` / `STRATUSSCAN_REGIONS` env var behavior is unchanged and still takes precedence
- `parse_known_args()` used throughout so pytest argv does not conflict with exporter argparse

## Acceptance criteria

- [x] `--region us-east-1` → scans only that region without prompting
- [x] `--regions us-east-1,us-west-2` → scans the listed regions
- [x] `--all-regions` → scans all regions for the detected partition
- [x] `--region` and `--all-regions` together → SystemExit (mutually exclusive)
- [x] `--profile my-profile` → uses named AWS profile via boto3 Session
- [x] `--output-dir /tmp/out` → writes exports to the specified directory
- [x] `--yes` / `-y` → skips confirmation prompts
- [x] No args → all defaults; existing interactive behavior preserved
- [x] `ruff check .` passes with no new violations
- [x] 14 new tests in `TestParseScriptArgs` — all passing
- [x] Pre-existing test suite: 414 passed, 2 pre-existing failures unchanged

## Test plan

- [ ] `python3 scripts/ec2_export.py --help` shows all flags
- [ ] `python3 scripts/ec2_export.py --region us-east-1 --yes` runs without prompts
- [ ] `python3 scripts/s3_export.py --all-regions` scans all partition regions
- [ ] `python3 scripts/rds_export.py --profile staging --output-dir /tmp/exports`
- [ ] `pytest tests/test_utils.py::TestParseScriptArgs -v` — 14/14 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)