### PR TITLE
feat(scan-sessions): progress tracking + resume for org-scan and smart-scan (#189)

### DIFF
--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -441,12 +441,23 @@ class ScriptExecutor:
         print("=" * 80)
         print()
 
-    def execute_all(self, show_progress: bool = True) -> Dict[str, Any]:
+    def execute_all(
+        self,
+        show_progress: bool = True,
+        session: Optional[dict] = None,
+        skip_scripts: Optional[Set[str]] = None,
+    ) -> Dict[str, Any]:
         """
         Execute all scripts in sequence.
 
         Args:
             show_progress: Whether to show progress display
+            session: Optional scan session dict from utils.start_scan_session().
+                     When provided, each completed script is recorded via
+                     utils.record_scan_result() and the session is marked
+                     complete after all scripts finish.
+            skip_scripts: Optional set of script filenames to skip (already
+                          completed in a prior session being resumed).
 
         Returns:
             Dictionary with execution summary:
@@ -462,6 +473,14 @@ class ScriptExecutor:
         batch_start = datetime.now()
 
         for script_name in self.scripts:
+            # Skip scripts already completed in a resumed session
+            if skip_scripts and script_name in skip_scripts:
+                if show_progress:
+                    self._show_progress(script_name)
+                    print(f"⏭  Skipped (already completed in prior session)")
+                    print()
+                continue
+
             # Find script path
             script_path = self._find_script_path(script_name)
 
@@ -481,6 +500,10 @@ class ScriptExecutor:
                     self._show_progress(script_name)
                     print(f"✗ Script not found: {script_name}")
                     print()
+                if session is not None:
+                    utils.record_scan_result(
+                        session, script_name, "failed", -1, 0.0, script=script_name
+                    )
                 continue
 
             # Show progress
@@ -491,6 +514,18 @@ class ScriptExecutor:
             result = self._execute_script(script_path)
             self.results.append(result)
 
+            # Persist result to session file
+            if session is not None:
+                status_str = "success" if result.success else "failed"
+                utils.record_scan_result(
+                    session,
+                    script_name,
+                    status_str,
+                    result.return_code,
+                    result.duration_seconds,
+                    script=script_name,
+                )
+
             # Brief pause between scripts
             if show_progress:
                 print()
@@ -498,6 +533,10 @@ class ScriptExecutor:
 
         batch_end = datetime.now()
         total_duration = (batch_end - batch_start).total_seconds()
+
+        # Mark session complete
+        if session is not None:
+            utils.complete_scan_session(session)
 
         # Show summary
         if show_progress:
@@ -584,6 +623,8 @@ def execute_scripts(
     save_log: bool = False,
     regions: Optional[List[str]] = None,
     show_output: bool = True,
+    session: Optional[dict] = None,
+    skip_scripts: Optional[Set[str]] = None,
 ) -> Dict[str, Any]:
     """
     Execute multiple scripts in batch.
@@ -595,12 +636,20 @@ def execute_scripts(
         regions: Regions to pass to subprocesses via STRATUSSCAN_REGIONS
         show_output: When True, stream script stdout to console in real time.
                      When False, capture silently (for future TUI use).
+        session: Optional scan session dict from utils.start_scan_session().
+                 When provided, results are persisted to disk after each script.
+        skip_scripts: Optional set of script filenames to skip (already
+                      completed in a resumed session).
 
     Returns:
         Execution summary dictionary
     """
     executor = ScriptExecutor(scripts, regions=regions, show_output=show_output)
-    summary = executor.execute_all(show_progress=show_progress)
+    summary = executor.execute_all(
+        show_progress=show_progress,
+        session=session,
+        skip_scripts=skip_scripts,
+    )
 
     if save_log:
         executor.save_execution_log()

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -459,6 +459,42 @@ def main() -> None:
         utils.log_info("No scripts selected. Exiting.")
         return
 
+    # Build planned list for session persistence
+    planned = [{"key": s, "script": s} for s in sorted(selected_scripts)]
+
+    # Offer resume of an interrupted smart-scan session
+    session: dict
+    skip_scripts: Optional[set] = None
+    interrupted_smart = [
+        s for s in utils.get_interrupted_sessions()
+        if s.get("scan_type") == "smart-scan"
+    ]
+    if interrupted_smart and not utils.is_auto_run():
+        prev = interrupted_smart[0]
+        n_done = len(prev.get("results", []))
+        n_total = len(prev.get("planned", []))
+        ans = input(
+            f"  Resume interrupted smart scan? ({n_done}/{n_total} scripts done) [y/n]: "
+        ).strip().lower()
+        if ans == "y":
+            utils.resume_scan_session(prev)
+            session = prev
+            done_keys = {r["key"] for r in prev.get("results", []) if r.get("status") == "success"}
+            selected_scripts = selected_scripts - done_keys
+            skip_scripts = None  # already filtered from selected_scripts
+        else:
+            session = utils.start_scan_session(
+                "smart-scan",
+                f"Smart Scan ({len(selected_scripts)} scripts)",
+                planned,
+            )
+    else:
+        session = utils.start_scan_session(
+            "smart-scan",
+            f"Smart Scan ({len(selected_scripts)} scripts)",
+            planned,
+        )
+
     print(f"\n  Executing {len(selected_scripts)} scripts...\n")
     summary = execute_scripts(
         selected_scripts,
@@ -466,6 +502,8 @@ def main() -> None:
         save_log=True,
         regions=regions,
         show_output=False,
+        session=session,
+        skip_scripts=skip_scripts,
     )
 
     # Zip all output files produced by this run

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -12,6 +12,7 @@ Usage:
     STRATUSSCAN_AUTO_RUN=1 python smart_scan.py  # CI / headless (Quick Scan)
 """
 
+import os
 import sys
 import zipfile
 from datetime import datetime
@@ -320,9 +321,59 @@ def _zip_export_files(results: list, account_name: str) -> Optional[Path]:
         return None
 
 
+def _resume_from_session(session_path: str) -> None:
+    """
+    Execute the remaining scripts from an interrupted smart-scan session.
+    Skips service discovery entirely — uses the planned list from the session file.
+    """
+    import json
+    try:
+        session: dict = json.loads(Path(session_path).read_text(encoding="utf-8"))
+        session["_path"] = session_path
+    except Exception as exc:
+        print(f"\n  ❌ Could not load session: {exc}")
+        return
+
+    done_keys = {r["key"] for r in session.get("results", []) if r.get("status") == "success"}
+    all_planned = {p["key"] for p in session.get("planned", [])}
+    remaining = all_planned - done_keys
+
+    n_done = len(done_keys)
+    n_total = len(session.get("planned", []))
+
+    print(f"\n  Resuming Smart Scan: {n_done}/{n_total} scripts already complete")
+    print(f"  {len(remaining)} script(s) remaining\n")
+
+    if not remaining:
+        print("  ✅ All scripts already completed.")
+        utils.complete_scan_session(session)
+        return
+
+    regions = utils.prompt_region_selection()
+    utils.resume_scan_session(session)
+
+    print(f"\n  Executing {len(remaining)} scripts...\n")
+    execute_scripts(
+        remaining,
+        show_progress=True,
+        save_log=False,
+        regions=regions,
+        show_output=False,
+        session=session,
+        skip_scripts=None,
+    )
+
+
 def main() -> None:
     """Main Smart Scan workflow."""
     utils.log_script_start('smart-scan')
+
+    # Startup resume: stratusscan.py passes session path via env var
+    resume_path = os.environ.get("STRATUSSCAN_RESUME_SESSION_PATH", "")
+    if resume_path:
+        utils.print_script_banner("SMART SCAN — RESUME INTERRUPTED SESSION")
+        _resume_from_session(resume_path)
+        return
 
     account_id, account_name = utils.print_script_banner(
         "SMART SCAN — SERVICE DISCOVERY & RECOMMENDATIONS"

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -65,8 +65,6 @@ utils.log_system_info()
 
 from utils import BackSignal, ExitToMainSignal, QuitSignal
 
-# Set to True after the interrupted-session notice is shown once per run
-_interruption_notice_shown: bool = False
 
 
 def prompt_with_navigation(prompt_text: str) -> str:
@@ -998,6 +996,137 @@ def show_scan_history() -> None:
             _show_session_detail(sessions[idx])
 
 
+def _resume_org_scan_from_session(session: dict) -> None:
+    """Execute remaining org-scan accounts from an interrupted session."""
+    planned = session.get("planned", [])
+    if not planned:
+        print("\n  ❌ Session has no planned entries — cannot resume.")
+        input("  Press Enter to return to menu...")
+        return
+
+    script_name = planned[0].get("script", "")
+    script_file = Path(__file__).parent / "scripts" / script_name
+    if not script_file.exists():
+        print(f"\n  ❌ Script {script_name} not found on disk — cannot resume.")
+        input("  Press Enter to return to menu...")
+        return
+
+    cross_account_roles = utils.get_cross_account_roles()
+    if not cross_account_roles:
+        print("\n  ❌ No cross-account roles configured.")
+        input("  Press Enter to return to menu...")
+        return
+
+    done_keys = {r["key"] for r in session.get("results", []) if r.get("status") == "success"}
+    remaining = {acct: role for acct, role in cross_account_roles.items() if acct not in done_keys}
+
+    SEP = "─" * 70
+    n_done = len(done_keys)
+    n_remaining = len(remaining)
+    print(f"\n  Script:   {script_name}")
+    print(f"  Done:     {n_done} account(s)")
+    print(f"  Pending:  {n_remaining} account(s)")
+    print(f"  {SEP}")
+
+    if not remaining:
+        print("\n  ✅ All accounts already completed. Marking session done.")
+        utils.complete_scan_session(session)
+        input("  Press Enter to return to menu...")
+        return
+
+    confirm = input(f"\n  Run {script_name} across {n_remaining} remaining account(s)? (y/n): ").strip().lower()
+    if confirm != "y":
+        return
+
+    utils.resume_scan_session(session)
+    results: list = []
+
+    for acct_id, role_arn in remaining.items():
+        acct_name = utils.get_account_name(acct_id)
+        print(f"\n  Scanning: {acct_name} ({acct_id})...")
+        child_env = os.environ.copy()
+        child_env["STRATUSSCAN_ROLE_ARN"] = role_arn
+        child_env["STRATUSSCAN_AUTO_RUN"] = "1"
+        start_t = time.monotonic()
+        exit_code = 0
+        try:
+            proc = subprocess.run([sys.executable, str(script_file)], env=child_env, timeout=1800)
+            exit_code = proc.returncode
+        except subprocess.TimeoutExpired:
+            utils.log_error("Resume org-scan: %s timed out", acct_id)
+            exit_code = -1
+        except Exception as exc:  # noqa: BLE001
+            utils.log_error("Resume org-scan: %s error: %s", acct_id, exc)
+            exit_code = -1
+        duration_s = time.monotonic() - start_t
+        status_str = "success" if exit_code == 0 else "failed"
+        utils.record_scan_result(session, acct_id, status_str, exit_code, duration_s,
+                                 script=script_name, account_id=acct_id, account_name=acct_name)
+        results.append({"acct_id": acct_id, "acct_name": acct_name, "exit_code": exit_code})
+
+    utils.complete_scan_session(session)
+    print(f"\n  RESUME COMPLETE")
+    print(f"  {SEP}")
+    for r in results:
+        icon = "✅" if r["exit_code"] == 0 else "❌"
+        status = "success" if r["exit_code"] == 0 else f"failed ({r['exit_code']})"
+        print(f"  {icon}  {r['acct_name']} ({r['acct_id']}) — {status}")
+    print(f"  {SEP}")
+    input("\n  Press Enter to return to menu...")
+
+
+def _startup_interrupted_check() -> None:
+    """
+    If an interrupted scan session exists, surface it immediately at startup
+    with a Y/N resume prompt — before the main menu renders.
+    """
+    interrupted = utils.get_interrupted_sessions()
+    if not interrupted:
+        return
+
+    session = interrupted[0]
+    scan_type = session.get("scan_type", "")
+    label = session.get("label", scan_type)
+    n_done = len(session.get("results", []))
+    n_total = len(session.get("planned", []))
+    ts = session.get("started_at", "")[:16].replace("T", " ")
+
+    SEP = "─" * 60
+    print()
+    print(f"  {SEP}")
+    print(f"  ⚠  INTERRUPTED SCAN DETECTED")
+    print(f"  {SEP}")
+    print(f"  {label}")
+    print(f"  Started: {ts}  |  Completed: {n_done}/{n_total}")
+    print(f"  {SEP}")
+    print("  [Y] Resume now")
+    print("  [N] Skip — go to main menu")
+    print("  [H] View scan history")
+    print(f"  {SEP}")
+
+    choice = input("\n  Choice [Y/N/H]: ").strip().upper() or "N"
+
+    if choice == "H":
+        show_scan_history()
+        return
+
+    if choice != "Y":
+        return
+
+    if scan_type == "org-scan":
+        _resume_org_scan_from_session(session)
+    elif scan_type == "smart-scan":
+        session_path = session.get("_path", "")
+        smart_scan_path = Path(__file__).parent / "smart_scan.py"
+        child_env = os.environ.copy()
+        child_env["STRATUSSCAN_RESUME_SESSION_PATH"] = session_path
+        subprocess.run([sys.executable, str(smart_scan_path)], env=child_env)
+        input("\n  Press Enter to return to menu...")
+    else:
+        print(f"\n  ❌ Unknown scan type '{scan_type}' — use [H] Scan History to view details.")
+        input("  Press Enter to return to menu...")
+
+
 def navigate_menus():
     """
     Display the main menu and handle user navigation through nested menus.
@@ -1008,8 +1137,7 @@ def navigate_menus():
             sys.exit(1)
 
         ensure_directory_structure()
-
-        global _interruption_notice_shown
+        _startup_interrupted_check()
 
         while True:
             menu_structure, account_name = display_main_menu()
@@ -1017,18 +1145,6 @@ def navigate_menus():
             if not menu_structure:
                 print("\nNo scripts found in the mapping. Please ensure script files exist in the scripts directory.")
                 sys.exit(1)
-
-            # Show interrupted-session notice once per process run
-            if not _interruption_notice_shown:
-                _interruption_notice_shown = True
-                interrupted = utils.get_interrupted_sessions()
-                if interrupted:
-                    s = interrupted[0]
-                    n_done = len(s.get("results", []))
-                    n_total = len(s.get("planned", []))
-                    ts = s.get("started_at", "")[:16].replace("T", " ")
-                    print(f"\n⚠  Interrupted scan: {s.get('label', s.get('scan_type', 'unknown'))} | {n_done}/{n_total} completed ({ts})")
-                    print("   Run [H] Scan History to view details or resume.\n")
 
             print("\nSelect an option:")
             try:

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -39,6 +39,7 @@ import logging
 import os
 import subprocess
 import sys
+import time
 import zipfile
 from pathlib import Path
 
@@ -63,6 +64,9 @@ utils.log_system_info()
 # ---------------------------------------------------------------------------
 
 from utils import BackSignal, ExitToMainSignal, QuitSignal
+
+# Set to True after the interrupted-session notice is shown once per run
+_interruption_notice_shown: bool = False
 
 
 def prompt_with_navigation(prompt_text: str) -> str:
@@ -634,7 +638,7 @@ def display_main_menu():
         print(f"  [{option:>2}] {info['name']}")
 
     print("\n" + "─" * 70)
-    print("  o = org scan  |  q = quit")
+    print("  o = org scan  |  h = scan history  |  q = quit")
     print("─" * 70)
 
     return menu_structure, account_name
@@ -839,11 +843,54 @@ def run_org_scan() -> None:
     if answer != "y":
         return
 
+    script_file: Path = selected_script["file"]
+
+    # Build planned list for session tracking
+    planned = [
+        {
+            "key": acct_id,
+            "script": script_file.name,
+            "account_id": acct_id,
+            "account_name": utils.get_account_name(acct_id),
+        }
+        for acct_id in cross_account_roles
+    ]
+
+    # Check for an interrupted session for the same script; offer resume
+    skip_accounts: set = set()
+    interrupted_sessions = [
+        s for s in utils.get_interrupted_sessions()
+        if any(p.get("script") == script_file.name for p in s.get("planned", []))
+    ]
+    if interrupted_sessions:
+        prev = interrupted_sessions[0]
+        n_done = len(prev.get("results", []))
+        n_total = len(prev.get("planned", []))
+        resume_ans = input(
+            f"  Resume interrupted session ({n_done}/{n_total} accounts completed)? (y/n): "
+        ).strip().lower()
+        if resume_ans == "y":
+            session = prev
+            utils.resume_scan_session(session)
+            skip_accounts = {
+                r["key"] for r in session.get("results", []) if r.get("status") == "success"
+            }
+        else:
+            label = f"{selected_script['name']} ({script_file.name}) — {n_accounts} accounts"
+            session = utils.start_scan_session("org-scan", label, planned)
+    else:
+        label = f"{selected_script['name']} ({script_file.name}) — {n_accounts} accounts"
+        session = utils.start_scan_session("org-scan", label, planned)
+
     # Execute across all accounts
     results: list = []
-    script_file: Path = selected_script["file"]
     for acct_id, role_arn in cross_account_roles.items():
         acct_name = utils.get_account_name(acct_id)
+
+        if acct_id in skip_accounts:
+            print(f"  ⏭  Skipping {acct_name} ({acct_id}) — already completed")
+            continue
+
         print(f"\nScanning account: {acct_name} ({acct_id})...")
 
         child_env = os.environ.copy()
@@ -851,6 +898,7 @@ def run_org_scan() -> None:
         child_env["STRATUSSCAN_AUTO_RUN"] = "1"
 
         exit_code: int = 0
+        start_time = time.monotonic()
         try:
             result = subprocess.run(
                 [sys.executable, str(script_file)],
@@ -868,7 +916,21 @@ def run_org_scan() -> None:
             utils.log_error("Org scan: account %s unexpected error: %s", acct_id, exc)
             exit_code = -1
 
+        duration_s = time.monotonic() - start_time
+        status_str = "success" if exit_code == 0 else "failed"
+        utils.record_scan_result(
+            session,
+            acct_id,
+            status_str,
+            exit_code,
+            duration_s,
+            script=script_file.name,
+            account_id=acct_id,
+            account_name=acct_name,
+        )
         results.append({"acct_id": acct_id, "acct_name": acct_name, "exit_code": exit_code})
+
+    utils.complete_scan_session(session)
 
     # Summary
     print(f"\nORG SCAN COMPLETE")
@@ -879,6 +941,61 @@ def run_org_scan() -> None:
         print(f"  {icon}  {r['acct_name']} ({r['acct_id']}) — {status}")
     print(SEP)
     input("\nPress Enter to return to menu...")
+
+
+def _show_session_detail(session: dict) -> None:
+    """Display per-item status for a single scan session."""
+    results_map = {r["key"]: r for r in session.get("results", [])}
+    planned = session.get("planned", [])
+    SEP = "─" * 70
+
+    print(f"\n{session.get('label', 'Session')} — {session.get('started_at', '')[:16]}")
+    print(SEP)
+
+    for item in planned:
+        key = item["key"]
+        if key in results_map:
+            r = results_map[key]
+            icon = "✅" if r["status"] == "success" else "❌"
+            label = item.get("account_name") or item.get("script") or key
+            print(f"  {icon} {label} ({key}) — {r['duration_s']}s")
+        else:
+            label = item.get("account_name") or item.get("script") or key
+            print(f"  ⏳ {label} ({key}) — not run")
+
+    print(SEP)
+    input("\nPress Enter to return...")
+
+
+def show_scan_history() -> None:
+    """Display recent scan sessions and allow drilling into details."""
+    sessions = utils.load_scan_sessions(10)
+    SEP = "─" * 70
+    print(f"\nSCAN HISTORY (last {len(sessions)} sessions)")
+    print(SEP)
+
+    if not sessions:
+        print("  No scan sessions found.")
+        input("\nPress Enter to return...")
+        return
+
+    for idx, s in enumerate(sessions, 1):
+        n_done = len(s.get("results", []))
+        n_total = len(s.get("planned", []))
+        status = s.get("status", "?")
+        icon = "✅" if status == "completed" else ("⚠ " if status == "running" else "?")
+        ts = s.get("started_at", "")[:16].replace("T", " ")
+        print(f"  [{idx}] {icon} {s.get('label', s.get('scan_type'))} — {n_done}/{n_total} | {ts}")
+
+    print(SEP)
+    print("  [#] View session details    [B] Back")
+    choice = input("\nSelect: ").strip().upper()
+    if choice == "B" or not choice:
+        return
+    if choice.isdigit():
+        idx = int(choice) - 1
+        if 0 <= idx < len(sessions):
+            _show_session_detail(sessions[idx])
 
 
 def navigate_menus():
@@ -892,12 +1009,26 @@ def navigate_menus():
 
         ensure_directory_structure()
 
+        global _interruption_notice_shown
+
         while True:
             menu_structure, account_name = display_main_menu()
 
             if not menu_structure:
                 print("\nNo scripts found in the mapping. Please ensure script files exist in the scripts directory.")
                 sys.exit(1)
+
+            # Show interrupted-session notice once per process run
+            if not _interruption_notice_shown:
+                _interruption_notice_shown = True
+                interrupted = utils.get_interrupted_sessions()
+                if interrupted:
+                    s = interrupted[0]
+                    n_done = len(s.get("results", []))
+                    n_total = len(s.get("planned", []))
+                    ts = s.get("started_at", "")[:16].replace("T", " ")
+                    print(f"\n⚠  Interrupted scan: {s.get('label', s.get('scan_type', 'unknown'))} | {n_done}/{n_total} completed ({ts})")
+                    print("   Run [H] Scan History to view details or resume.\n")
 
             print("\nSelect an option:")
             try:
@@ -908,6 +1039,11 @@ def navigate_menus():
                 return
             except (BackSignal, ExitToMainSignal):
                 continue  # Already at main menu — just redisplay
+
+            # Scan history (special key — not in menu_structure dict)
+            if user_choice.upper() == "H":
+                show_scan_history()
+                continue
 
             if user_choice not in menu_structure:
                 print("Invalid selection. Please try again.")

--- a/tests/test_scan_session.py
+++ b/tests/test_scan_session.py
@@ -1,0 +1,182 @@
+"""
+Tests for scan session persistence (utils.py SCAN SESSION TRACKING section).
+"""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+# Ensure project root is importable
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import utils
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def patch_output_dir(tmp_path, monkeypatch):
+    """Redirect get_output_dir() to a temp directory for every test."""
+    monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+    yield tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _session_file(session: dict) -> Path:
+    return Path(session["_path"])
+
+
+def _read_session_file(session: dict) -> dict:
+    return json.loads(_session_file(session).read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStartScanSession:
+    def test_creates_file(self, tmp_path):
+        session = utils.start_scan_session(
+            scan_type="org-scan",
+            label="Test Run",
+            planned=[{"key": "111111111111", "account_id": "111111111111"}],
+        )
+        assert _session_file(session).exists(), "Session file should be created on disk"
+
+    def test_correct_fields(self, tmp_path):
+        planned = [{"key": "abc", "script": "ec2_export.py"}]
+        session = utils.start_scan_session("smart-scan", "My Label", planned)
+
+        data = _read_session_file(session)
+        assert data["scan_type"] == "smart-scan"
+        assert data["label"] == "My Label"
+        assert data["status"] == "running"
+        assert data["completed_at"] is None
+        assert data["planned"] == planned
+        assert data["results"] == []
+        assert "session_id" in data
+        assert "started_at" in data
+
+    def test_path_not_written_to_file(self, tmp_path):
+        """Internal _path key must not leak into the JSON file."""
+        session = utils.start_scan_session("org-scan", "L", [{"key": "k"}])
+        data = _read_session_file(session)
+        assert "_path" not in data
+
+
+class TestRecordScanResult:
+    def test_appends_result(self, tmp_path):
+        session = utils.start_scan_session("org-scan", "L", [
+            {"key": "111"},
+            {"key": "222"},
+        ])
+        utils.record_scan_result(session, "111", "success", 0, 12.3, account_id="111")
+        utils.record_scan_result(session, "222", "failed", 1, 7.0, account_id="222")
+
+        data = _read_session_file(session)
+        assert len(data["results"]) == 2
+
+    def test_result_fields(self, tmp_path):
+        session = utils.start_scan_session("org-scan", "L", [{"key": "999"}])
+        utils.record_scan_result(
+            session, "999", "success", 0, 45.678,
+            account_name="Prod", script="ec2_export.py",
+        )
+
+        data = _read_session_file(session)
+        r = data["results"][0]
+        assert r["key"] == "999"
+        assert r["status"] == "success"
+        assert r["exit_code"] == 0
+        assert r["duration_s"] == 45.7  # rounded to 1 decimal
+        assert r["account_name"] == "Prod"
+        assert r["script"] == "ec2_export.py"
+        assert "completed_at" in r
+
+    def test_in_memory_session_also_updated(self, tmp_path):
+        """record_scan_result must update the in-memory session dict too."""
+        session = utils.start_scan_session("org-scan", "L", [{"key": "x"}])
+        utils.record_scan_result(session, "x", "success", 0, 1.0)
+        assert len(session["results"]) == 1
+
+
+class TestCompleteScanSession:
+    def test_marks_completed(self, tmp_path):
+        session = utils.start_scan_session("smart-scan", "L", [{"key": "s1"}])
+        utils.complete_scan_session(session)
+
+        data = _read_session_file(session)
+        assert data["status"] == "completed"
+        assert data["completed_at"] is not None
+
+    def test_in_memory_status_updated(self, tmp_path):
+        session = utils.start_scan_session("smart-scan", "L", [{"key": "s1"}])
+        utils.complete_scan_session(session)
+        assert session["status"] == "completed"
+
+
+class TestGetInterruptedSessions:
+    def test_returns_running_only(self, tmp_path):
+        running = utils.start_scan_session("org-scan", "Running", [{"key": "a"}])
+        time.sleep(1.1)  # ensure distinct session_id (1-second filename resolution)
+        completed = utils.start_scan_session("org-scan", "Completed", [{"key": "b"}])
+        utils.complete_scan_session(completed)
+
+        interrupted = utils.get_interrupted_sessions()
+        session_ids = [s["session_id"] for s in interrupted]
+        assert running["session_id"] in session_ids
+        assert completed["session_id"] not in session_ids
+
+    def test_empty_when_none_running(self, tmp_path):
+        session = utils.start_scan_session("org-scan", "Done", [{"key": "a"}])
+        utils.complete_scan_session(session)
+        assert utils.get_interrupted_sessions() == []
+
+
+class TestLoadScanSessions:
+    def test_limit_respected(self, tmp_path):
+        # Create 3 sessions with small time gaps so filenames differ
+        for i in range(3):
+            utils.start_scan_session("org-scan", f"Run {i}", [{"key": str(i)}])
+            # Tiny sleep so strftime timestamps differ (1-second resolution)
+            time.sleep(1.1)
+
+        loaded = utils.load_scan_sessions(limit=2)
+        assert len(loaded) == 2
+
+    def test_newest_first(self, tmp_path):
+        s1 = utils.start_scan_session("org-scan", "First", [{"key": "1"}])
+        time.sleep(1.1)
+        s2 = utils.start_scan_session("org-scan", "Second", [{"key": "2"}])
+
+        loaded = utils.load_scan_sessions(limit=10)
+        ids = [s["session_id"] for s in loaded]
+        assert ids.index(s2["session_id"]) < ids.index(s1["session_id"])
+
+    def test_path_injected(self, tmp_path):
+        utils.start_scan_session("org-scan", "L", [{"key": "k"}])
+        loaded = utils.load_scan_sessions()
+        assert all("_path" in s for s in loaded)
+
+
+class TestResumeScanSession:
+    def test_resets_to_running(self, tmp_path):
+        session = utils.start_scan_session("org-scan", "L", [{"key": "a"}])
+        utils.complete_scan_session(session)
+        assert session["status"] == "completed"
+
+        utils.resume_scan_session(session)
+        assert session["status"] == "running"
+        assert session["completed_at"] is None
+
+        data = _read_session_file(session)
+        assert data["status"] == "running"
+        assert data["completed_at"] is None

--- a/utils.py
+++ b/utils.py
@@ -3983,3 +3983,123 @@ def generate_cost_optimization_recommendations(
         recommendations.append("No specific cost optimization recommendations at this time")
 
     return recommendations
+
+
+# ============================================================================
+# SCAN SESSION TRACKING
+# ============================================================================
+
+def _get_scan_sessions_dir() -> Path:
+    """Return (and create) the scan-sessions directory inside the output dir."""
+    sessions_dir = get_output_dir() / "scan-sessions"
+    sessions_dir.mkdir(parents=True, exist_ok=True)
+    return sessions_dir
+
+
+def start_scan_session(scan_type: str, label: str, planned: list) -> dict:
+    """
+    Create a new scan session file and return the session dict.
+
+    Args:
+        scan_type: 'org-scan' or 'smart-scan'
+        label: Human-readable run description
+        planned: List of dicts, each with at least 'key' (unique per item)
+
+    Returns:
+        Session dict — pass to record_scan_result() and complete_scan_session()
+    """
+    session_id = datetime.datetime.now().strftime("%Y%m%d-%H%M%S")
+    session_path = _get_scan_sessions_dir() / f"scan-{session_id}.json"
+    session = {
+        "session_id": session_id,
+        "scan_type": scan_type,
+        "label": label,
+        "status": "running",
+        "started_at": datetime.datetime.now().isoformat(timespec="seconds"),
+        "completed_at": None,
+        "planned": planned,
+        "results": [],
+        "_path": str(session_path),
+    }
+    _write_scan_session(session)
+    return session
+
+
+def _write_scan_session(session: dict) -> None:
+    """Atomically write session dict to its file (temp-rename pattern)."""
+    path = Path(session["_path"])
+    data = {k: v for k, v in session.items() if not k.startswith("_")}
+    tmp = path.with_suffix(".tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except Exception as exc:
+        log_warning(f"Failed to write scan session: {exc}")
+
+
+def record_scan_result(
+    session: dict,
+    key: str,
+    status: str,
+    exit_code: int,
+    duration_s: float,
+    **kwargs,
+) -> None:
+    """
+    Append a completed item to the session file.
+
+    Args:
+        session: Session dict from start_scan_session()
+        key: Unique key matching a 'planned' entry
+        status: 'success' or 'failed'
+        exit_code: Process exit code
+        duration_s: Wall-clock seconds
+        **kwargs: Extra fields to include (account_id, account_name, script, etc.)
+    """
+    result = {
+        "key": key,
+        "status": status,
+        "exit_code": exit_code,
+        "duration_s": round(duration_s, 1),
+        "completed_at": datetime.datetime.now().isoformat(timespec="seconds"),
+        **kwargs,
+    }
+    session["results"].append(result)
+    _write_scan_session(session)
+
+
+def complete_scan_session(session: dict) -> None:
+    """Mark session as completed and write final state."""
+    session["status"] = "completed"
+    session["completed_at"] = datetime.datetime.now().isoformat(timespec="seconds")
+    _write_scan_session(session)
+
+
+def load_scan_sessions(limit: int = 10) -> list:
+    """Load recent scan sessions, newest first."""
+    try:
+        sessions_dir = _get_scan_sessions_dir()
+    except Exception:
+        return []
+    files = sorted(sessions_dir.glob("scan-*.json"), reverse=True)[:limit]
+    sessions = []
+    for f in files:
+        try:
+            data = json.loads(f.read_text(encoding="utf-8"))
+            data["_path"] = str(f)
+            sessions.append(data)
+        except Exception:
+            pass
+    return sessions
+
+
+def get_interrupted_sessions() -> list:
+    """Return sessions that were never completed (status still 'running')."""
+    return [s for s in load_scan_sessions(20) if s.get("status") == "running"]
+
+
+def resume_scan_session(session: dict) -> None:
+    """Mark an interrupted session as running again (for resume flows)."""
+    session["status"] = "running"
+    session["completed_at"] = None
+    _write_scan_session(session)


### PR DESCRIPTION
## Summary

Addresses the CloudShell timeout pain point: scan runs across many accounts or many scripts are now persisted to disk as they execute. If CloudShell dies mid-run, a session file in `output/scan-sessions/` shows exactly what completed and what was pending. On the next launch, the tool detects the interrupted session and offers to resume from where it stopped.

**How it works:**
- A `scan-{YYYYMMDD-HHMMSS}.json` file is created before any scripts run, with the full planned list
- After each script/account completes, the file is updated atomically (temp-file rename — safe against partial writes)
- `status: running` stays until normal completion (`status: completed`); a CloudShell kill leaves it as `running` — that's the interrupted-run signal
- On next launch, a one-time notice appears: `⚠  Interrupted scan: EC2 Export — 3/8 accounts completed (05.15.2026 14:32)`
- `[H] Scan History` in the main menu shows the last 10 sessions with completion counts; selecting a session shows per-item status (✅ done / ⏳ not run / ❌ failed)

**Resume logic:**
- Org-scan: if an interrupted session exists for the same exporter script, user is asked to resume. Accounts already marked `success` in the old session are skipped
- Smart scan: same pattern — completed scripts are filtered out of the run set; new results are appended to the existing session file

**Scope:** org-scan + smart scan. Aggregate scripts (compute_resources.py etc.) run as single subprocess calls from the menu and are tracked as single entries — enough to see pass/fail but not sub-script granularity.

## Files changed

- `utils.py` — 8 new session management functions (~120 lines)
- `stratusscan.py` — org-scan wiring, startup notice, `[H]` history menu
- `scripts/smart_scan/executor.py` — optional session + skip_scripts params in `execute_all()`
- `smart_scan.py` — session creation + resume detection before execution
- `tests/test_scan_session.py` — 14 new tests (session lifecycle, atomic writes, interrupted detection)

## Test plan

- [ ] Run org-scan across 2+ accounts; kill terminal mid-run; relaunch — verify interrupted notice + resume offer
- [ ] Run smart scan; kill mid-run; relaunch smart_scan.py — verify resume offer skips completed scripts
- [ ] `[H]` Scan History shows sessions with correct counts
- [ ] `pytest` — 428 pass, 2 pre-existing executor failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)