### PR TITLE
fix(security): contain caller-controlled file paths (CWE-73) + close _scrub_log gap

### DIFF
--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -569,8 +569,8 @@ class ScriptExecutor:
             timestamp = datetime.now().strftime("%m.%d.%Y-%H%M")
             filename = f"smart-scan-execution-log-{timestamp}.txt"
 
-        log_path = utils.get_output_dir() / filename
         try:
+            log_path = utils.get_output_filepath(filename)
             with open(log_path, "w", encoding='utf-8') as f:
                 f.write("=" * 80 + "\n")
                 f.write(" " * 26 + "SMART SCAN EXECUTION LOG\n")
@@ -613,7 +613,7 @@ class ScriptExecutor:
             return True
 
         except Exception as e:
-            utils.log_error(f"Error saving execution log to {log_path}", e)
+            utils.log_error(f"Error saving execution log to {filename}", e)
             return False
 
 

--- a/scripts/smart_scan/selector.py
+++ b/scripts/smart_scan/selector.py
@@ -354,7 +354,10 @@ class SmartScanSelector:
             filename = f"smart-scan-checklist-{timestamp}.txt"
 
         try:
-            with open(filename, "w", encoding='utf-8') as f:
+            # Write into output/ alongside every other artifact, with the same
+            # containment check the exporters use (CWE-73).
+            checklist_path = utils.get_output_filepath(filename)
+            with open(checklist_path, "w", encoding='utf-8') as f:
                 f.write("=" * 80 + "\n")
                 f.write(" " * 28 + "SMART SCAN CHECKLIST\n")
                 f.write("=" * 80 + "\n\n")
@@ -394,7 +397,7 @@ class SmartScanSelector:
                 f.write("=" * 80 + "\n")
 
             print()
-            print(f"{utils.GLYPH_OK} Checklist saved to: {filename}")
+            print(f"{utils.GLYPH_OK} Checklist saved to: {checklist_path}")
             print()
             return True
 

--- a/tests/smart_scan/test_executor.py
+++ b/tests/smart_scan/test_executor.py
@@ -274,19 +274,36 @@ class TestExecutionFlow:
             assert isinstance(summary, dict)
             assert "total" in summary
 
-    def test_save_execution_log(self):
-        """Test saving execution log to file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            executor = ScriptExecutor({"test.py"})
+    def test_save_execution_log(self, tmp_path, monkeypatch):
+        """The execution log is written into the output directory, never to a
+        caller-supplied location outside it (CWE-73)."""
+        import utils
 
-            log_file = Path(tmpdir) / "test-execution.log"
-            result = executor.save_execution_log(str(log_file))
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
 
-            # Should return True even if no results (empty log)
-            assert isinstance(result, bool)
+        assert executor.save_execution_log("test-execution.log") is True
+        assert (tmp_path / "test-execution.log").exists()
 
-            if result:
-                assert log_file.exists()
+    def test_save_execution_log_contains_traversal(self, tmp_path, monkeypatch):
+        """A traversing filename is reduced to a bare name inside output/."""
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
+
+        assert executor.save_execution_log("../../escaped.log") is True
+        assert (tmp_path / "escaped.log").exists()
+        assert not (tmp_path.parent.parent / "escaped.log").exists()
+
+    def test_save_execution_log_rejects_unusable_name(self, tmp_path, monkeypatch):
+        """A name with no usable component returns False rather than raising."""
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
+
+        assert executor.save_execution_log("..") is False
 
 
 class TestProgressDisplay:

--- a/tests/smart_scan/test_selector.py
+++ b/tests/smart_scan/test_selector.py
@@ -122,3 +122,66 @@ class TestPlainTextFallback:
         with patch.object(selector, "QUESTIONARY_AVAILABLE", False):
             result = selector.interactive_select({"all_scripts": set()})
         assert result is None
+
+
+@pytest.fixture
+def make_selector():
+    """Build a SmartScanSelector without requiring questionary to be installed.
+
+    The constructor guards on QUESTIONARY_AVAILABLE, but save_checklist() is a
+    plain file writer that never touches questionary.
+    """
+    from smart_scan import selector as selector_module
+
+    def _make(recommendations=MOCK_RECOMMENDATIONS):
+        with patch.object(selector_module, "QUESTIONARY_AVAILABLE", True):
+            return SmartScanSelector(recommendations)
+
+    return _make
+
+
+class TestSaveChecklistContainment:
+    """save_checklist() writes into output/ — previously it wrote to a bare
+    relative path, dropping the checklist in the caller's CWD (CWE-73)."""
+
+    def test_checklist_written_to_output_dir(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("checklist.txt") is True
+        assert (tmp_path / "checklist.txt").exists()
+
+    def test_checklist_not_written_to_cwd(self, tmp_path, monkeypatch, make_selector):
+        """Regression: the file must not land in the current working directory."""
+        import utils
+
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        monkeypatch.chdir(cwd)
+        monkeypatch.setattr(utils, "get_output_dir", lambda: out)
+        selector = make_selector()
+
+        assert selector.save_checklist("checklist.txt") is True
+        assert (out / "checklist.txt").exists()
+        assert not (cwd / "checklist.txt").exists()
+
+    def test_traversing_name_stays_contained(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("../../escaped.txt") is True
+        assert (tmp_path / "escaped.txt").exists()
+
+    def test_unusable_name_returns_false(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("..") is False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -645,3 +645,134 @@ class TestParseScriptArgs:
     def teardown_method(self, method):
         """Reset _SCRIPT_ARGS after each test to avoid cross-test contamination."""
         utils._SCRIPT_ARGS = None
+
+
+class TestSanitizeFilenameComponent:
+    """sanitize_filename_component() strips path-altering characters (CWE-73)
+    without disturbing ordinary names."""
+
+    @pytest.mark.parametrize("value", [
+        'PROD-ACCOUNT',
+        'ec2',
+        'my account 01',
+        'acct_name-v2',
+        'Account.Name',
+        '',
+    ])
+    def test_ordinary_names_pass_through_unchanged(self, value):
+        assert utils.sanitize_filename_component(value) == value
+
+    def test_forward_slash_stripped(self):
+        assert utils.sanitize_filename_component('a/b') == 'ab'
+
+    def test_backslash_stripped(self):
+        assert utils.sanitize_filename_component(r'a\b') == 'ab'
+
+    def test_parent_directory_marker_stripped(self):
+        assert utils.sanitize_filename_component('../etc') == 'etc'
+
+    def test_nested_parent_markers_cannot_reconstitute(self):
+        # A single non-repeating pass on '....' would leave '..'
+        assert '..' not in utils.sanitize_filename_component('....')
+
+    def test_null_byte_stripped(self):
+        assert utils.sanitize_filename_component('a\x00b') == 'ab'
+
+    def test_control_characters_stripped(self):
+        assert utils.sanitize_filename_component('a\r\nb') == 'ab'
+
+    def test_leading_and_trailing_dots_and_spaces_stripped(self):
+        assert utils.sanitize_filename_component('  .hidden.  ') == 'hidden'
+
+    def test_traversal_payload_is_defanged(self):
+        assert utils.sanitize_filename_component('../../etc/passwd') == 'etcpasswd'
+
+    def test_non_string_input_coerced(self):
+        assert utils.sanitize_filename_component(42) == '42'
+
+
+class TestContainedPath:
+    """contained_path() confines a caller-supplied name to a base directory."""
+
+    def test_plain_filename_resolves_inside_base(self, tmp_path):
+        result = utils.contained_path(tmp_path, 'report.xlsx')
+        assert result == tmp_path / 'report.xlsx'
+
+    def test_traversal_is_reduced_to_basename(self, tmp_path):
+        # basename() collapses the traversal rather than escaping
+        result = utils.contained_path(tmp_path, '../../etc/passwd')
+        assert result == tmp_path / 'passwd'
+        assert result.parent == tmp_path
+
+    def test_absolute_path_is_reduced_to_basename(self, tmp_path):
+        result = utils.contained_path(tmp_path, '/etc/shadow')
+        assert result == tmp_path / 'shadow'
+
+    @pytest.mark.parametrize("bad", ['', '.', '..', '/', '../'])
+    def test_names_with_no_usable_component_are_rejected(self, tmp_path, bad):
+        with pytest.raises(ValueError):
+            utils.contained_path(tmp_path, bad)
+
+    def test_result_never_escapes_base(self, tmp_path):
+        for candidate in ['a/b/c.txt', '../x.txt', './y.txt', 'z.txt']:
+            result = utils.contained_path(tmp_path, candidate)
+            assert result.resolve().parent == tmp_path.resolve()
+
+    def test_get_output_filepath_delegates_to_containment(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(utils, 'get_output_dir', lambda: tmp_path)
+        assert utils.get_output_filepath('../escape.xlsx') == tmp_path / 'escape.xlsx'
+
+
+class TestExportFilenameContainment:
+    """A crafted account_name in config.json must not steer the export path."""
+
+    def test_normal_account_name_is_untouched(self):
+        filename = utils.create_export_filename(
+            account_name='PROD-ACCOUNT', resource_type='ec2', suffix='running'
+        )
+        assert filename.startswith('PROD-ACCOUNT-ec2-running-export-')
+
+    def test_traversal_in_account_name_is_stripped(self):
+        filename = utils.create_export_filename(
+            account_name='../../etc', resource_type='ec2', suffix=''
+        )
+        assert '..' not in filename
+        assert '/' not in filename
+
+    def test_traversal_in_resource_type_is_stripped(self):
+        filename = utils.create_export_filename(
+            account_name='ACCT', resource_type='../ec2', suffix=''
+        )
+        assert '..' not in filename
+        assert '/' not in filename
+
+    def test_sanitized_filename_stays_contained(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(utils, 'get_output_dir', lambda: tmp_path)
+        filename = utils.create_export_filename(
+            account_name='../../../tmp/evil', resource_type='ec2', suffix=''
+        )
+        assert utils.get_output_filepath(filename).parent == tmp_path
+
+
+class TestLogErrorScrubbing:
+    """Every log_error() branch must scrub CRLF (CWE-117), including the
+    debug/stack-trace branch."""
+
+    def test_debug_branch_scrubs_crlf(self):
+        mock_logger = Mock()
+        with patch.object(utils, 'get_logger', return_value=mock_logger):
+            utils.log_error('boom', ValueError('line1\r\nFAKE: forged entry'))
+
+        debug_message = mock_logger.debug.call_args[0][0]
+        assert '\n' not in debug_message
+        assert '\r' not in debug_message
+        assert 'FAKE: forged entry' in debug_message
+
+    def test_error_branch_still_scrubs_crlf(self):
+        mock_logger = Mock()
+        with patch.object(utils, 'get_logger', return_value=mock_logger):
+            utils.log_error('boom', ValueError('a\r\nb'))
+
+        error_message = mock_logger.error.call_args[0][0]
+        assert '\n' not in error_message
+        assert '\r' not in error_message

--- a/utils.py
+++ b/utils.py
@@ -586,7 +586,7 @@ def log_error(error_message: str, error_obj: Optional[Exception] = None) -> None
     if error_obj:
         current_logger.error(_scrub_log(f"{error_message}: {str(error_obj)}"))
         # Log stack trace for debugging
-        current_logger.debug(f"Exception details: {error_obj}", exc_info=True)
+        current_logger.debug(_scrub_log(f"Exception details: {error_obj}"), exc_info=True)
     else:
         current_logger.error(_scrub_log(error_message))
 
@@ -977,6 +977,60 @@ def get_output_dir() -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 
+# Characters that can redirect a path or corrupt a filename: path separators,
+# Windows-reserved punctuation, and control characters (including NUL).
+_UNSAFE_NAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+def sanitize_filename_component(value: object) -> str:
+    """
+    Reduce an untrusted value to a safe single filename component (CWE-73).
+
+    Strips — rather than substitutes — path separators, control characters, and
+    parent-directory markers, so ordinary names (letters, digits, spaces, dots,
+    hyphens, underscores) are returned byte-identical and existing export
+    filenames are unaffected.
+
+    Args:
+        value: The untrusted value (e.g. an account name from config.json)
+
+    Returns:
+        str: The value with path-altering characters removed
+    """
+    text = _UNSAFE_NAME_CHARS.sub("", str(value))
+    # Remove parent-directory markers, repeating until stable so that crafted
+    # sequences like '....' cannot reconstitute a '..' after a single pass.
+    while ".." in text:
+        text = text.replace("..", "")
+    # A leading dot would hide the file; a trailing dot/space is stripped by
+    # some filesystems and would let two distinct names collide.
+    return text.strip(" .")
+
+def contained_path(base_dir: "str | Path", filename: str) -> Path:
+    """
+    Resolve ``filename`` to a direct child of ``base_dir``, refusing escapes.
+
+    Containment (CWE-73): reduce to a bare filename and confirm it resolves to a
+    direct child of the base directory, so a crafted name containing path
+    separators or '..' cannot escape it. Ordinary bare filenames pass through
+    unchanged.
+
+    Args:
+        base_dir: The directory the file must live directly inside
+        filename: The candidate filename
+
+    Returns:
+        Path: ``base_dir`` joined with the validated bare filename
+
+    Raises:
+        ValueError: If the name would resolve outside ``base_dir``.
+    """
+    base = Path(base_dir).resolve()
+    safe_name = os.path.basename(str(filename))
+    resolved = (base / safe_name).resolve()
+    if safe_name in ("", ".", "..") or resolved.parent != base:
+        raise ValueError(f"Refusing path outside {base}: {filename!r}")
+    return base / safe_name
+
 def get_output_filepath(filename: str) -> Path:
     """
     Get the full path for a file in the output directory.
@@ -990,16 +1044,7 @@ def get_output_filepath(filename: str) -> Path:
     Raises:
         ValueError: If the name would resolve outside the output directory.
     """
-    output_dir = get_output_dir().resolve()
-    # Containment (CWE-73): reduce to a bare filename and confirm it resolves to
-    # a direct child of the output directory, so a crafted name containing path
-    # separators or '..' cannot escape it. Standard export filenames are already
-    # bare and pass through unchanged.
-    safe_name = os.path.basename(filename)
-    resolved = (output_dir / safe_name).resolve()
-    if safe_name in ("", ".", "..") or resolved.parent != output_dir:
-        raise ValueError(f"Refusing output path outside output directory: {filename!r}")
-    return output_dir / safe_name
+    return contained_path(get_output_dir(), filename)
 
 def create_export_filename(
     account_name: str,
@@ -1030,6 +1075,13 @@ def create_export_filename(
     # Get current date if not provided
     if not current_date:
         current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+
+    # Sanitize caller-supplied components (CWE-73): account_name comes from the
+    # account_mappings in config.json, so a crafted entry must not be able to
+    # steer the export out of the output directory. Ordinary names are unchanged.
+    account_name = sanitize_filename_component(account_name)
+    resource_type = sanitize_filename_component(resource_type)
+    suffix = sanitize_filename_component(suffix)
 
     # Build the base filename
     if suffix:
@@ -2655,9 +2707,13 @@ class ProgressCheckpoint:
         self.checkpoint_dir = Path(checkpoint_dir)
         self.checkpoint_dir.mkdir(exist_ok=True)
 
-        # Checkpoint file path
+        # Checkpoint file path — operation_name is caller-supplied, so sanitize
+        # the component and confirm containment in checkpoint_dir (CWE-73).
         timestamp = datetime.datetime.now().strftime("%Y%m%d")
-        self.checkpoint_file = self.checkpoint_dir / f"{operation_name}_{timestamp}.json"
+        safe_operation = sanitize_filename_component(operation_name)
+        self.checkpoint_file = contained_path(
+            self.checkpoint_dir, f"{safe_operation}_{timestamp}.json"
+        )
 
         # Load existing checkpoint if available
         self.checkpoint_data = self._load()


### PR DESCRIPTION
Closes #253.

Static analysis flagged six sites that build a file path from a caller-controlled value with no check that the result stays inside its intended directory (CWE-73). `utils.get_output_filepath()` already implemented the correct containment pattern — `os.path.basename()`, resolve, assert the parent is the intended directory — but nothing else reused it.

## Changes

**New shared helpers in `utils.py`**

- `contained_path(base_dir, filename)` — the containment logic lifted out of `get_output_filepath()`, now usable against any base directory. `get_output_filepath()` delegates to it, so existing callers see no behavior change.
- `sanitize_filename_component(value)` — **strips** rather than substitutes path separators, control characters (including NUL), and parent-directory markers. Stripping matters: substituting with `-` would have introduced `--` into export filenames and changed output users depend on. Ordinary names (letters, digits, spaces, dots, hyphens, underscores) come back byte-identical.

**Applied at the six sites**

| Site | Change |
|---|---|
| `create_export_filename()` | Sanitize `account_name` / `resource_type` / `suffix` before interpolation. `account_name` comes from `account_mappings` in `config.json`, so a crafted entry could previously steer the export out of `output/`. |
| `ProgressCheckpoint.__init__` | Sanitize `operation_name` and contain `checkpoint_file` under `checkpoint_dir`. |
| `ScriptExecutor.save_execution_log()` | Use `get_output_filepath()` instead of `get_output_dir() / filename`. |
| `SmartScanSelector.save_checklist()` | Same — **and this fixes a real bug**: it was calling `open(filename, "w")` on a bare relative path, so the checklist landed in the caller's CWD rather than `output/`. Its sibling in `executor.py` already used `get_output_dir()`. |

**Two supporting fixes**

- Both path resolutions moved *inside* their `try` blocks. A rejected name now returns `False` like every other failure in those methods instead of propagating — and `executor`'s handler previously referenced `log_path` on a path where it would have been unbound.
- `log_error()`'s debug/stack-trace branch now passes through `_scrub_log()`. It was the one `log_*` path in `utils.py` that did not, while the error branch on the adjacent line did (CWE-117). An AWS API error carrying CRLF could forge log lines.

## Tests

+36 tests:

- `sanitize_filename_component` — ordinary names unchanged (parametrized), separators / NUL / control chars / traversal payloads stripped, `....` cannot reconstitute `..` after one pass, non-string input coerced
- `contained_path` — plain names resolve inside base, traversal and absolute paths reduced to basename, unusable names (`''`, `.`, `..`, `/`) rejected, result never escapes base
- `create_export_filename` — normal names produce the exact existing filename; traversal in `account_name` or `resource_type` is stripped and the result stays contained
- `save_execution_log` / `save_checklist` — write into `output/`, contain traversal, return `False` on unusable names; explicit regression test that the checklist does *not* land in the CWD
- `log_error` — both branches scrub CRLF while preserving the message text

Full suite **1311 passed / 2 skipped** (baseline on dev was 1274). `ruff check .` clean.

## Note on an updated test

`tests/smart_scan/test_executor.py::test_save_execution_log` previously passed an absolute tmpdir path and asserted the file appeared there. That is precisely the behavior this PR removes, so the test now asserts the log lands in `output/` instead. It is also one of the tests called out in #197 as coupled to the real `output/` directory; it now patches `get_output_dir`.

`test_get_account_name_with_mapping` fails when `tests/test_utils.py` is run in isolation, both before and after this branch. That is #201 and is untouched here; it passes in the full-suite run.
