### PR TITLE
Release v0.7.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ StratusScanCLI-AWS is in active beta development. The API and output format may 
 | Version | Target | Notes |
 |---|---|---|
 | `0.6.x` | Patch releases | Coverage gaps, pricing data refresh, live-account hardening |
-| `1.0.0` | Planned | Full Textual-based TUI; subprocess output streamed live |
+| `1.0.0` | Planned | Stable API; unattended audit mode — scheduled, cross-account, S3-delivered runs |
 
 ---
 
@@ -443,8 +443,10 @@ StratusScanCLI-AWS uses [Semantic Versioning](https://semver.org/).
 | `0.1.x` | Superseded | Initial relaunch |
 | `0.2.x` | Superseded | Backend stabilization, pricing data v2 |
 | `0.3.x` | Superseded | Smart Scan orchestrator, full API correctness audit |
-| `0.4.x` | Current (Beta) | Cost columns for 14 exporters, pricing JSON overhaul |
-| `1.0.0` | Planned | Textual TUI, stable API |
+| `0.4.x` | Superseded | Cost columns for 14 exporters, pricing JSON overhaul |
+| `0.5.x` | Superseded | Multi-account org-scan, CLI flags, signal-based navigation, export formats |
+| `0.6.x` | Current (Beta) | Fail-loud collection sweep, security hardening, smart-scan discovery |
+| `1.0.0` | Planned | Stable API; unattended audit mode |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # StratusScanCLI-AWS
 
-[![Version: 0.6.0](https://img.shields.io/badge/version-0.6.0-blue.svg)](https://github.com/ColonelPanicX/StratusScanCLI-AWS/releases)
+[![Version: 0.7.0](https://img.shields.io/badge/version-0.7.0-blue.svg)](https://github.com/ColonelPanicX/StratusScanCLI-AWS/releases)
 [![Status: Beta](https://img.shields.io/badge/status-beta-yellow.svg)](#project-status)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![License: GPL-3.0](https://img.shields.io/badge/License-GPL%203.0-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -388,11 +388,18 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the exporter script template and cont
 
 ## Project Status
 
-**Current version: 0.6.0-beta**
+**Current version: 0.7.0-beta**
 
 StratusScanCLI-AWS is in active beta development. The API and output format may change before the 1.0.0 stable release. All active development occurs on the `dev` branch; `main` is release snapshots only.
 
-### What's new in v0.6.0
+### What's new in v0.7.0
+
+- **Unattended audit mode (manual half)**: The pieces needed to run a full audit without a human at the keyboard. `--run-all` executes every exporter in one headless pass and writes a spreadsheet run report; `--org-scan` extends that across every account in an AWS Organization via `--scan-role`; exports can be delivered straight to S3 instead of the local `output/` directory; and each run emits a manifest recording what ran, what it found, and what failed. Empty exports are suppressed by default — an exporter that finds nothing writes no spreadsheet, but the run report still records it as "ran, 0 assets" (#175, #199, #202, #203, #204).
+- **One interaction voice across the CLI**: Every interactive surface — menus, multi-selects, confirmations, the config wizards — now speaks a single contract. Numbered `1..N` menus, `b` = back / `x` = main menu / `q` = quit everywhere, two-tier confirmations, and consistent ✅/❌ status glyphs. This replaces five competing prompt dialects that had accumulated across the codebase; the Cost Management all-in-one menu in particular no longer changes input style between steps. Three latent bugs surfaced and were fixed in the process: the Cost bundle silently skipped Compute Optimizer, Smart Scan ran everything when `questionary` was absent instead of offering a real fallback, and the services-in-use exporter ignored the region back/exit signal (#252).
+- **Path-handling hardening**: File paths built from caller-supplied values are now validated against a single containment helper, so a crafted account name in `config.json` cannot steer an export outside its intended directory (CWE-73). Closes a real bug found alongside it — the Smart Scan checklist was written to the current working directory rather than `output/` (#253).
+- **Smart Scan discovery**: `Amazon CloudWatch Logs` now resolves to the CloudWatch exporter instead of being misclassified as having no exporter (#251).
+
+### Previously in v0.6.0
 
 - **Fail-loud collection (reliability)**: All 96 region- and account-scoped exporters now surface collection failures instead of silently emitting empty results. On an API failure an exporter writes a `*-FAILED-*.txt` marker and exits non-zero; a genuinely empty account still exits 0. This makes partial or failed audits detectable rather than indistinguishable from an empty account. **Behavior change:** automation keying on exit codes will now see a non-zero exit on collection errors.
 - **Security hardening**: Python floor raised to 3.10 (pulls the patched `urllib3 2.7.0`); subprocess launcher containment guard (only known, validated scripts can run); log-forging (CWE-117) and file-path (CWE-73) cleanup; `os.system` screen-clear replaced with an ANSI escape.
@@ -428,8 +435,8 @@ StratusScanCLI-AWS is in active beta development. The API and output format may 
 
 | Version | Target | Notes |
 |---|---|---|
-| `0.6.x` | Patch releases | Coverage gaps, pricing data refresh, live-account hardening |
-| `1.0.0` | Planned | Stable API; unattended audit mode — scheduled, cross-account, S3-delivered runs |
+| `0.7.x` | Patch releases | Coverage gaps, pricing data refresh, live-account hardening |
+| `1.0.0` | Planned | Stable API; scheduled unattended audit mode — one-command deployment of the recurring runner (the manual cross-account and S3-delivery half shipped in `0.7.0`) |
 
 ---
 
@@ -445,8 +452,9 @@ StratusScanCLI-AWS uses [Semantic Versioning](https://semver.org/).
 | `0.3.x` | Superseded | Smart Scan orchestrator, full API correctness audit |
 | `0.4.x` | Superseded | Cost columns for 14 exporters, pricing JSON overhaul |
 | `0.5.x` | Superseded | Multi-account org-scan, CLI flags, signal-based navigation, export formats |
-| `0.6.x` | Current (Beta) | Fail-loud collection sweep, security hardening, smart-scan discovery |
-| `1.0.0` | Planned | Stable API; unattended audit mode |
+| `0.6.x` | Superseded | Fail-loud collection sweep, security hardening, smart-scan discovery |
+| `0.7.x` | Current (Beta) | Unattended audit mode (manual half), single-voice CLI, path-handling hardening |
+| `1.0.0` | Planned | Stable API; scheduled unattended audit mode |
 
 ---
 

--- a/advanced_settings.py
+++ b/advanced_settings.py
@@ -92,12 +92,10 @@ def configure_concurrent_scanning():
 
     # Enable/disable concurrent scanning
     enabled_str = 'Yes' if current['concurrent_scanning']['enabled'] else 'No'
-    enabled_input = input(f"\nEnable concurrent scanning? (Y/n) [Current: {enabled_str}]: ").strip().lower()
-
-    if enabled_input == '':
-        enabled = current['concurrent_scanning']['enabled']
-    else:
-        enabled = enabled_input != 'n'
+    enabled = utils.prompt_for_confirmation(
+        f"\nEnable concurrent scanning? [Current: {enabled_str}]",
+        default=current['concurrent_scanning']['enabled'],
+    )
 
     if enabled:
         # Configure max workers
@@ -116,12 +114,10 @@ def configure_concurrent_scanning():
 
         # Fallback on error
         fallback_str = 'Yes' if current['concurrent_scanning']['fallback_on_error'] else 'No'
-        fallback_input = input(f"\nFallback to sequential scanning on errors? (Y/n) [Current: {fallback_str}]: ").strip().lower()
-
-        if fallback_input == '':
-            fallback = current['concurrent_scanning']['fallback_on_error']
-        else:
-            fallback = fallback_input != 'n'
+        fallback = utils.prompt_for_confirmation(
+            f"\nFallback to sequential scanning on errors? [Current: {fallback_str}]",
+            default=current['concurrent_scanning']['fallback_on_error'],
+        )
     else:
         max_workers = current['concurrent_scanning']['max_workers']
         fallback = current['concurrent_scanning']['fallback_on_error']
@@ -204,9 +200,10 @@ def configure_caching():
 
     # Enable/disable caching
     enabled_str = 'Yes' if current['caching']['enabled'] else 'No'
-    enabled_input = input(f"\nEnable caching? (Y/n) [Current: {enabled_str}]: ").strip().lower()
-
-    enabled = current['caching']['enabled'] if enabled_input == '' else enabled_input != 'n'
+    enabled = utils.prompt_for_confirmation(
+        f"\nEnable caching? [Current: {enabled_str}]",
+        default=current['caching']['enabled'],
+    )
 
     if enabled:
         # Cache expiration
@@ -367,14 +364,14 @@ def reset_to_defaults():
     print("  - Caching: Enabled (session-only)")
     print("  - Performance: Default tuning values")
 
-    confirm = input("\nAre you sure you want to reset? (yes/no): ").strip().lower()
+    confirm = utils.prompt_for_confirmation("\nAre you sure you want to reset?", default=False)
 
-    if confirm == 'yes':
+    if confirm:
         defaults = get_default_settings()
         save_settings(defaults)
-        print("\n✓ All settings have been reset to defaults.")
+        print(f"\n{utils.GLYPH_OK} All settings have been reset to defaults.")
     else:
-        print("\n✗ Reset cancelled.")
+        print(f"\n{utils.GLYPH_FAIL} Reset cancelled.")
 
 
 def main():
@@ -386,44 +383,46 @@ def main():
     print("Settings are stored in config.json and apply to all export scripts.")
 
     while True:
-        print("\n" + "="*70)
-        print("MAIN MENU")
-        print("="*70)
-        print("\n[1] View Current Settings")
-        print("[2] Configure Concurrent Scanning")
-        print("[3] Configure Progress Display")
-        print("[4] Configure Caching")
-        print("[5] Configure Performance Tuning")
-        print("[6] Reset to Defaults")
-        print("[0] Exit")
-
-        choice = input("\nSelect option: ").strip()
-
-        if choice == '0':
+        try:
+            choice = utils.prompt_menu(
+                "MAIN MENU",
+                [
+                    "View Current Settings",
+                    "Configure Concurrent Scanning",
+                    "Configure Progress Display",
+                    "Configure Caching",
+                    "Configure Performance Tuning",
+                    "Reset to Defaults",
+                    "Exit",
+                ],
+            )
+        except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
             print("\nExiting advanced settings. Changes have been saved.")
             break
-        elif choice == '1':
+
+        if choice == 1:
             display_current_settings()
-        elif choice == '2':
+        elif choice == 2:
             current = get_current_settings()
             current['concurrent_scanning'] = configure_concurrent_scanning()
             save_settings(current)
-        elif choice == '3':
+        elif choice == 3:
             current = get_current_settings()
             current['progress_display'] = configure_progress_display()
             save_settings(current)
-        elif choice == '4':
+        elif choice == 4:
             current = get_current_settings()
             current['caching'] = configure_caching()
             save_settings(current)
-        elif choice == '5':
+        elif choice == 5:
             current = get_current_settings()
             current['performance'] = configure_performance()
             save_settings(current)
-        elif choice == '6':
+        elif choice == 6:
             reset_to_defaults()
-        else:
-            print("\n  ERROR: Invalid option. Please try again.")
+        elif choice == 7:
+            print("\nExiting advanced settings. Changes have been saved.")
+            break
 
 
 if __name__ == '__main__':

--- a/config-template.json
+++ b/config-template.json
@@ -9,9 +9,10 @@
   "agency_name": "YOUR-AGENCY",
   "default_regions": ["us-east-1", "us-west-2"],
   "output_settings": {
-    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). Set via 'python configure.py' -> Output Settings.",
+    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). skip_empty_exports: when true, an exporter that finds no resources writes no spreadsheet (the run report still records it as 'ran, 0 assets'). Set via 'python configure.py' -> Output Settings.",
     "format": "xlsx",
     "destination": "local",
+    "skip_empty_exports": true,
     "s3": {
       "bucket": "",
       "prefix": "stratusscan/"

--- a/config-template.json
+++ b/config-template.json
@@ -9,8 +9,13 @@
   "agency_name": "YOUR-AGENCY",
   "default_regions": ["us-east-1", "us-west-2"],
   "output_settings": {
-    "__comment": "Export format: xlsx (requires openpyxl) or csv. Set automatically by Config Wizard.",
-    "format": "xlsx"
+    "__comment": "format: xlsx (requires openpyxl) or csv. destination: 'local' (saves to output/) or 's3' (uploads to the bucket below, then deletes the local copy on success). Set via 'python configure.py' -> Output Settings.",
+    "format": "xlsx",
+    "destination": "local",
+    "s3": {
+      "bucket": "",
+      "prefix": "stratusscan/"
+    }
   },
   "resource_preferences": {
     "ec2": {

--- a/configure.py
+++ b/configure.py
@@ -691,29 +691,32 @@ def configure_output_settings(config: dict):
             print(f"  S3 bucket:   {bucket}")
             print(f"  S3 prefix:   {prefix}")
         print()
-        print("  [1] Change export format (xlsx/csv)")
-        print("  [2] Change destination (local/s3)")
-        print("  [3] Set S3 bucket")
-        print("  [4] Set S3 prefix")
-        print("  [5] Test S3 connection")
-        print("  [B] Back to main menu")
-
-        choice = input("\nSelect option: ").strip().upper()
-
-        if choice == "1":
-            _set_output_format(config)
-        elif choice == "2":
-            _set_output_destination(config)
-        elif choice == "3":
-            _set_s3_bucket(config)
-        elif choice == "4":
-            _set_s3_prefix(config)
-        elif choice == "5":
-            _run_s3_connectivity_test(config)
-        elif choice in ("B", ""):
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Change export format (xlsx/csv)",
+                    "Change destination (local/s3)",
+                    "Set S3 bucket",
+                    "Set S3 prefix",
+                    "Test S3 connection",
+                ],
+            )
+        except utils.BackSignal:
             return
-        else:
-            print("  ❌ Invalid choice.")
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
+
+        if choice == 1:
+            _set_output_format(config)
+        elif choice == 2:
+            _set_output_destination(config)
+        elif choice == 3:
+            _set_s3_bucket(config)
+        elif choice == 4:
+            _set_s3_prefix(config)
+        elif choice == 5:
+            _run_s3_connectivity_test(config)
 
 
 def config_wizard(config: dict):
@@ -800,8 +803,8 @@ def main_menu_loop(config: dict, config_path: Path):
                 print("SAVE CONFIGURATION")
                 print("═" * 70)
                 display_summary(config)
-                confirm = input("\nSave this configuration? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation("\nSave this configuration?", default=False)
+                if confirm:
                     if save_configuration(config, config_path):
                         print("\n✅ Configuration saved successfully!")
                         print("You can now use StratusScan with your configured settings.")
@@ -821,8 +824,8 @@ def main_menu_loop(config: dict, config_path: Path):
             # Exit without saving
             if _config_modified:
                 print("\n⚠️  WARNING: You have unsaved changes!")
-                confirm = input("Exit without saving? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation("Exit without saving?", default=False)
+                if confirm:
                     print("\n❌ Configuration not saved. Exiting...")
                     return
                 else:
@@ -886,15 +889,17 @@ def manage_account_mappings(config: dict):
         else:
             print("  None configured")
 
-        print("\nOptions:")
-        print("  [A] Add new account")
-        print("  [E] Edit existing account")
-        print("  [D] Delete account")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                ["Add new account", "Edit existing account", "Delete account"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (A/E/D/B): ").strip().upper()
-
-        if choice == 'A':
+        if choice == 1:
             # Fetch current account identity for defaults
             identity = get_aws_identity()
             default_id = identity['account_id'] if identity and identity.get('account_id') != 'Unknown' else ''
@@ -917,8 +922,10 @@ def manage_account_mappings(config: dict):
                     break
                 if validate_account_id(account_id):
                     if account_id in mappings:
-                        overwrite = input(f"Account {account_id} already exists. Overwrite? (y/n): ").lower().strip()
-                        if overwrite != 'y':
+                        overwrite = utils.prompt_for_confirmation(
+                            f"Account {account_id} already exists. Overwrite?", default=False
+                        )
+                        if not overwrite:
                             continue
                     break
                 else:
@@ -936,7 +943,7 @@ def manage_account_mappings(config: dict):
                 else:
                     print("\n❌ Account name cannot be empty")
 
-        elif choice == 'E':
+        elif choice == 2:
             # Edit existing account
             if not mappings:
                 print("\n❌ No accounts to edit")
@@ -959,7 +966,7 @@ def manage_account_mappings(config: dict):
             else:
                 print(f"\n❌ Account {account_id} not found")
 
-        elif choice == 'D':
+        elif choice == 3:
             # Delete account
             if not mappings:
                 print("\n❌ No accounts to delete")
@@ -968,21 +975,16 @@ def manage_account_mappings(config: dict):
 
             account_id = input("\nEnter Account ID to delete: ").strip()
             if account_id in mappings:
-                confirm = input(f"Delete {account_id} ({mappings[account_id]})? (y/n): ").lower().strip()
-                if confirm == 'y':
+                confirm = utils.prompt_for_confirmation(
+                    f"Delete {account_id} ({mappings[account_id]})?", default=False
+                )
+                if confirm:
                     del mappings[account_id]
                     config['account_mappings'] = mappings
                     _config_modified = True
                     print(f"\n✅ Deleted: {account_id}")
             else:
                 print(f"\n❌ Account {account_id} not found")
-
-        elif choice == 'B':
-            # Back to main menu
-            return
-
-        else:
-            print("\n❌ Invalid choice. Please select A/E/D/B.")
 
 def configure_default_regions(config: dict):
     """Configure default regions."""
@@ -997,31 +999,34 @@ def configure_default_regions(config: dict):
     print(f"\nCurrent default regions: {', '.join(current_regions) if current_regions else 'None'}")
 
     if is_govcloud:
-        print("\n  1. GovCloud — both regions (us-gov-west-1, us-gov-east-1)")
-        print("  C. Custom — enter regions manually")
-        presets = {"1": ["us-gov-west-1", "us-gov-east-1"]}
+        preset_label = "GovCloud — both regions (us-gov-west-1, us-gov-east-1)"
+        preset_regions = ["us-gov-west-1", "us-gov-east-1"]
     else:
-        print("\n  1. US Standard — us-east-1, us-east-2, us-west-1, us-west-2")
-        print("  C. Custom — enter regions manually")
-        presets = {"1": ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]}
+        preset_label = "US Standard — us-east-1, us-east-2, us-west-1, us-west-2"
+        preset_regions = ["us-east-1", "us-east-2", "us-west-1", "us-west-2"]
 
     # Validates standard AWS region format: us-east-1, eu-west-2, us-gov-west-1, etc.
     region_pattern = re.compile(r'^[a-z]{2,3}(-[a-z]+)+-\d+$')
 
     while True:
-        choice = input("\nSelect option (1, C for custom, 0 to cancel): ").strip().upper()
-
-        if choice == '0':
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [preset_label, "Custom — enter regions manually"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
             return
 
-        if choice in presets:
-            regions = presets[choice]
+        if choice == 1:
+            regions = preset_regions
             config['default_regions'] = regions
             _config_modified = True
             print(f"\n✅ Default regions set: {', '.join(regions)}")
             break
 
-        elif choice == 'C':
+        elif choice == 2:
             raw = input("  Regions, comma-separated (e.g. eu-west-1,ap-northeast-1): ").strip().lower()
             if not raw:
                 continue
@@ -1043,9 +1048,6 @@ def configure_default_regions(config: dict):
             _config_modified = True
             print(f"\n✅ Default regions set: {', '.join(regions)}")
             break
-
-        else:
-            print("  ❌ Invalid choice. Enter 1, C, or 0.")
 
     input("\nPress Enter to return to menu...")
 
@@ -1080,14 +1082,17 @@ def manage_cross_account_roles(config: dict):
         else:
             print("  None configured")
 
-        print("\nOptions:")
-        print("  [A] Add role")
-        print("  [R] Remove role")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                ["Add role", "Remove role"],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (A/R/B): ").strip().upper()
-
-        if choice == 'A':
+        if choice == 1:
             while True:
                 account_id = input("\nEnter target AWS Account ID (12 digits): ").strip()
                 if not account_id:
@@ -1123,7 +1128,7 @@ def manage_cross_account_roles(config: dict):
                 print(f"\n❌ Failed to add role for account {account_id}")
             input("Press Enter to continue...")
 
-        elif choice == 'R':
+        elif choice == 2:
             if not real_roles:
                 print("\n❌ No roles configured to remove")
                 input("Press Enter to continue...")
@@ -1140,10 +1145,10 @@ def manage_cross_account_roles(config: dict):
                 input("Press Enter to continue...")
                 continue
 
-            confirm = input(
-                f"Remove role for {account_id} ({roles[account_id]})? (y/n): "
-            ).lower().strip()
-            if confirm == 'y':
+            confirm = utils.prompt_for_confirmation(
+                f"Remove role for {account_id} ({roles[account_id]})?", default=False
+            )
+            if confirm:
                 if utils.remove_cross_account_role(account_id):
                     del roles[account_id]
                     config['cross_account_roles'] = roles
@@ -1154,12 +1159,6 @@ def manage_cross_account_roles(config: dict):
             else:
                 print("\n↩ Cancelled")
             input("Press Enter to continue...")
-
-        elif choice == 'B':
-            return
-
-        else:
-            print("\n❌ Invalid choice. Please select A, R, or B.")
 
 
 # ============================================================================
@@ -1190,18 +1189,24 @@ def dependency_management_menu():
             input("\nPress Enter to return to menu...")
             return
 
-        print("\nOptions:")
-        print("  [1] Install missing dependencies automatically")
-        print("  [2] Show installation commands for manual installation")
-        print("  [3] Re-check dependencies")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Install missing dependencies automatically",
+                    "Show installation commands for manual installation",
+                    "Re-check dependencies",
+                ],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (1-3, B): ").strip().upper()
-
-        if choice == '1':
+        if choice == 1:
             install_dependencies(_dependency_status['missing_packages'])
             _dependency_status = check_dependencies_silent()
-        elif choice == '2':
+        elif choice == 2:
             print("\n" + "═" * 70)
             print("MANUAL INSTALLATION COMMANDS")
             print("═" * 70)
@@ -1211,14 +1216,9 @@ def dependency_management_menu():
             print("\nAlternatively, install all at once:")
             print(f"pip install {' '.join([p['name'] for p in _dependency_status['missing_packages']])}")
             input("\nPress Enter to continue...")
-        elif choice == '3':
+        elif choice == 3:
             print("\n🔄 Re-checking dependencies...")
             continue
-        elif choice == 'B':
-            return
-        else:
-            print("\n❌ Invalid choice. Please select 1-3 or B.")
-            input("Press Enter to continue...")
 
 def install_dependencies(missing_packages: list[dict]) -> bool:
     """
@@ -1241,9 +1241,11 @@ def install_dependencies(missing_packages: list[dict]) -> bool:
     for package in missing_packages:
         print(f"  - {package['name']} - {package['description']}")
 
-    confirm = input(f"\nInstall these {len(missing_packages)} packages now? (y/n): ").lower().strip()
+    confirm = utils.prompt_for_confirmation(
+        f"\nInstall these {len(missing_packages)} packages now?", default=True
+    )
 
-    if confirm != 'y':
+    if not confirm:
         print("\n❌ Installation cancelled.")
         input("Press Enter to continue...")
         return False
@@ -1304,12 +1306,17 @@ def permissions_management_menu():
         if not identity:
             print("\n❌ No AWS credentials found!")
             print("Please configure your AWS credentials before running StratusScan.")
-            print("\nOptions:")
-            print("  [1] Show credential configuration help")
-            print("  [B] Back to main menu")
+            try:
+                choice = utils.prompt_menu(
+                    "Select an option",
+                    ["Show credential configuration help"],
+                )
+            except utils.BackSignal:
+                return
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                return
 
-            choice = input("\nSelect option (1, B): ").strip().upper()
-            if choice == '1':
+            if choice == 1:
                 print("\n" + "═" * 70)
                 print("AWS CREDENTIALS SETUP")
                 print("═" * 70)
@@ -1322,8 +1329,6 @@ def permissions_management_menu():
                 print("\n3. IAM Role (for EC2 instances)")
                 print("   Attach an IAM role to your EC2 instance")
                 input("\nPress Enter to continue...")
-            elif choice == 'B':
-                return
             continue
 
         print(f"\nAWS Identity: {identity['arn']}")
@@ -1343,26 +1348,27 @@ def permissions_management_menu():
             print(f"\n❌ {_permission_status['required_failed']} required permissions are missing!")
             print("StratusScan scripts may fail without these permissions.")
 
-        print("\nOptions:")
-        print("  [1] Show policy recommendations")
-        print("  [2] View policy file locations")
-        print("  [3] Re-test permissions")
-        print("  [B] Back to main menu")
+        try:
+            choice = utils.prompt_menu(
+                "Select an option",
+                [
+                    "Show policy recommendations",
+                    "View policy file locations",
+                    "Re-test permissions",
+                ],
+            )
+        except utils.BackSignal:
+            return
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            return
 
-        choice = input("\nSelect option (1-3, B): ").strip().upper()
-
-        if choice == '1':
+        if choice == 1:
             show_policy_recommendations_brief()
-        elif choice == '2':
+        elif choice == 2:
             show_policy_file_locations()
-        elif choice == '3':
+        elif choice == 3:
             print("\n🔄 Re-testing permissions...")
             continue
-        elif choice == 'B':
-            return
-        else:
-            print("\n❌ Invalid choice. Please select 1-3 or B.")
-            input("Press Enter to continue...")
 
 def show_policy_recommendations_brief():
     """Show brief policy recommendations."""

--- a/configure.py
+++ b/configure.py
@@ -1063,7 +1063,7 @@ def manage_cross_account_roles(config: dict):
     """
     Interactive menu for managing cross-account IAM role mappings.
 
-    Mirrors manage_account_mappings() — [A]dd, [R]emove, [B]ack.
+    Mirrors manage_account_mappings() — numbered Add / Remove menu, b = back.
     Validates role ARN format before delegating to utils.
     """
     global _config_modified

--- a/configure.py
+++ b/configure.py
@@ -427,8 +427,17 @@ def print_dashboard(config: dict, config_path: Path):
     config_status = get_config_status(config, config_path)
     print_status_line("Configuration", config_status, 70)
 
-    output_fmt = config.get("output_settings", {}).get("format", utils.detect_default_format())
+    out_settings = config.get("output_settings", {})
+    output_fmt = out_settings.get("format", utils.detect_default_format())
     print_status_line("Export Format", output_fmt, 70)
+
+    destination = out_settings.get("destination", "local")
+    if destination == "s3":
+        bucket = (out_settings.get("s3", {}) or {}).get("bucket", "")
+        dest_str = f"S3: {bucket}" if bucket else "S3 (bucket not set!)"
+    else:
+        dest_str = "local (output/)"
+    print_status_line("Output Destination", dest_str, 70)
 
     print("╚" + "═" * 68 + "╝")
 
@@ -485,8 +494,11 @@ def print_dashboard(config: dict, config_path: Path):
     role_status = f"{role_count} configured" if role_count else "None configured"
     print(f"  [6] Cross-Account Roles                    {role_status}")
 
-    output_fmt = config.get("output_settings", {}).get("format", utils.detect_default_format())
-    print(f"  [7] Output Format                          {output_fmt}")
+    out_settings = config.get("output_settings", {})
+    output_fmt = out_settings.get("format", utils.detect_default_format())
+    out_dest = out_settings.get("destination", "local")
+    dest_label = "S3" if out_dest == "s3" else "local"
+    print(f"  [7] Output Settings                        {output_fmt} → {dest_label}")
 
     # Actions
     print("\nActions:")
@@ -495,30 +507,26 @@ def print_dashboard(config: dict, config_path: Path):
 
     print("\n" + "═" * 70)
 
-def configure_output_settings(config: dict):
-    """
-    Configure the export output format (xlsx or csv).
+def _ensure_output_settings(config: dict) -> dict:
+    """Return config['output_settings'], creating it (and the nested s3 block) if absent."""
+    out = config.setdefault("output_settings", {})
+    out.setdefault("s3", {})
+    return out
 
-    Reads current output_settings from config, shows the current value, and
-    prompts the user to change it. Updates config in place and sets the
-    _config_modified flag when a change is made.
 
-    Args:
-        config (dict): Configuration dictionary (mutated in place)
-    """
+def _set_output_format(config: dict):
+    """Prompt for and apply the export format (xlsx/csv)."""
     global _config_modified
 
-    current_settings = config.get("output_settings", {})
-    current_fmt = current_settings.get("format", utils.detect_default_format())
+    out = _ensure_output_settings(config)
+    current_fmt = out.get("format", utils.detect_default_format())
 
-    print("\n" + "═" * 70)
-    print("OUTPUT FORMAT SETTINGS")
-    print("═" * 70)
-    print(f"  Current format: {current_fmt}")
-    print()
+    print("\n" + "─" * 70)
+    print("EXPORT FORMAT")
+    print("─" * 70)
+    print(f"  Current: {current_fmt}")
     print("  [1] xlsx  — Excel workbook (requires openpyxl)")
     print("  [2] csv   — Universal CSV (stdlib only, multi-sheet exports split into files)")
-    print()
     choice = input("Select format (1/2, or Enter to keep current): ").strip()
 
     if choice == "1":
@@ -527,19 +535,185 @@ def configure_output_settings(config: dict):
         new_fmt = "csv"
     else:
         print("  No change made.")
-        input("\nPress Enter to return to menu...")
         return
 
     if new_fmt == current_fmt:
         print(f"  Format already set to '{new_fmt}'. No change.")
     else:
-        if "output_settings" not in config:
-            config["output_settings"] = {}
-        config["output_settings"]["format"] = new_fmt
+        out["format"] = new_fmt
         _config_modified = True
         print(f"  Export format set to '{new_fmt}'.")
 
-    input("\nPress Enter to return to menu...")
+
+def _set_output_destination(config: dict):
+    """Prompt for and apply the output destination (local/s3)."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current_dest = out.get("destination", "local")
+
+    print("\n" + "─" * 70)
+    print("OUTPUT DESTINATION")
+    print("─" * 70)
+    print(f"  Current: {current_dest}")
+    print("  [1] local — save to output/ (default)")
+    print("  [2] s3    — upload to an S3 bucket, then delete the local copy on success")
+    choice = input("Select destination (1/2, or Enter to keep current): ").strip()
+
+    if choice == "1":
+        new_dest = "local"
+    elif choice == "2":
+        new_dest = "s3"
+    else:
+        print("  No change made.")
+        return
+
+    if new_dest == current_dest:
+        print(f"  Destination already set to '{new_dest}'. No change.")
+    else:
+        out["destination"] = new_dest
+        _config_modified = True
+        print(f"  Output destination set to '{new_dest}'.")
+
+    if new_dest == "s3" and not out.get("s3", {}).get("bucket"):
+        print("  ⚠️  No S3 bucket configured yet — set it with [3] before exporting.")
+
+
+def _set_s3_bucket(config: dict):
+    """Prompt for and apply the S3 bucket name."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current = out["s3"].get("bucket", "")
+
+    print("\n" + "─" * 70)
+    print("S3 BUCKET")
+    print("─" * 70)
+    print(f"  Current: {current or '(not set)'}")
+    new_bucket = input("Enter S3 bucket name (Enter to keep current): ").strip()
+    if not new_bucket:
+        print("  No change made.")
+        return
+
+    out["s3"]["bucket"] = new_bucket
+    _config_modified = True
+    print(f"  S3 bucket set to '{new_bucket}'.")
+
+
+def _set_s3_prefix(config: dict):
+    """Prompt for and apply the S3 key prefix."""
+    global _config_modified
+
+    out = _ensure_output_settings(config)
+    current = out["s3"].get("prefix", "stratusscan/")
+
+    print("\n" + "─" * 70)
+    print("S3 PREFIX")
+    print("─" * 70)
+    print(f"  Current: {current}")
+    print("  Key prefix within the bucket (e.g. 'stratusscan/'). Enter '/' for no prefix.")
+    new_prefix = input("Enter S3 prefix (Enter to keep current): ").strip()
+    if not new_prefix:
+        print("  No change made.")
+        return
+
+    new_prefix = "" if new_prefix == "/" else new_prefix
+    out["s3"]["prefix"] = new_prefix
+    _config_modified = True
+    print(f"  S3 prefix set to '{new_prefix}'.")
+
+
+def _run_s3_connectivity_test(config: dict):
+    """Run the HeadBucket → PutObject → DeleteObject roundtrip and print results."""
+    out = _ensure_output_settings(config)
+    bucket = out["s3"].get("bucket", "")
+    prefix = out["s3"].get("prefix", "stratusscan/")
+
+    print("\n" + "─" * 70)
+    print("TEST S3 CONNECTION")
+    print("─" * 70)
+
+    if not bucket:
+        print("  ❌ No S3 bucket configured. Set one with [3] first.")
+        return
+
+    print(f"  Bucket: {bucket}")
+    print(f"  Prefix: {prefix}")
+    print("  Running HeadBucket → PutObject → DeleteObject ...\n")
+
+    result = utils.test_s3_connectivity(bucket, prefix)
+
+    if result.get("region"):
+        print(f"  Region: {result['region']}")
+    for step in result["steps"]:
+        if step["ok"]:
+            print(f"  ✅ {step['step']}")
+        else:
+            print(f"  ❌ {step['step']}")
+            print(f"       {step['error']}")
+
+    print()
+    if result["ok"]:
+        print("  ✅ S3 connectivity OK — exports will upload to this bucket.")
+    else:
+        failed = result.get("failed_step")
+        print(f"  ❌ S3 connectivity FAILED at step: {failed}")
+        print("     Common causes: wrong region, PutObject denied by bucket policy/KMS/VPC")
+        print("     endpoint condition, prefix-level permission mismatch, or Block Public")
+        print("     Access conflict. See policies/s3-upload-permissions.json for the")
+        print("     minimum IAM grant required.")
+
+
+def configure_output_settings(config: dict):
+    """
+    Configure export output settings: format, destination, and S3 details.
+
+    Submenu loop covering format (xlsx/csv), destination (local/s3), S3 bucket
+    and prefix, and an on-demand S3 connectivity test. Mutates config in place
+    and sets _config_modified when a change is made.
+
+    Args:
+        config (dict): Configuration dictionary (mutated in place)
+    """
+    while True:
+        out = _ensure_output_settings(config)
+        fmt = out.get("format", utils.detect_default_format())
+        dest = out.get("destination", "local")
+        bucket = out["s3"].get("bucket", "") or "(not set)"
+        prefix = out["s3"].get("prefix", "stratusscan/")
+
+        print("\n" + "═" * 70)
+        print("OUTPUT SETTINGS")
+        print("═" * 70)
+        print(f"  Format:      {fmt}")
+        print(f"  Destination: {dest}")
+        if dest == "s3":
+            print(f"  S3 bucket:   {bucket}")
+            print(f"  S3 prefix:   {prefix}")
+        print()
+        print("  [1] Change export format (xlsx/csv)")
+        print("  [2] Change destination (local/s3)")
+        print("  [3] Set S3 bucket")
+        print("  [4] Set S3 prefix")
+        print("  [5] Test S3 connection")
+        print("  [B] Back to main menu")
+
+        choice = input("\nSelect option: ").strip().upper()
+
+        if choice == "1":
+            _set_output_format(config)
+        elif choice == "2":
+            _set_output_destination(config)
+        elif choice == "3":
+            _set_s3_bucket(config)
+        elif choice == "4":
+            _set_s3_prefix(config)
+        elif choice == "5":
+            _run_s3_connectivity_test(config)
+        elif choice in ("B", ""):
+            return
+        else:
+            print("  ❌ Invalid choice.")
 
 
 def config_wizard(config: dict):
@@ -562,7 +736,8 @@ def config_wizard(config: dict):
     _clr()
     print("✅ Step 1/6 complete — Account Mappings\n")
     print("Step 2/6 — Export Format\n")
-    configure_output_settings(config)
+    _set_output_format(config)
+    input("\nPress Enter to continue...")
 
     _clr()
     print("✅ Step 2/6 complete — Export Format\n")

--- a/policies/s3-upload-permissions.json
+++ b/policies/s3-upload-permissions.json
@@ -1,0 +1,24 @@
+{
+  "__comment": "StratusScan S3 upload (Issue #175). Grants ONLY the write-only access needed to deliver exports to one bucket/prefix — separate and independently auditable from the read-only scan policies. Replace YOUR-BUCKET-NAME with your bucket and adjust the 'stratusscan/' prefix to match output_settings.s3.prefix. For GovCloud use partition 'aws-us-gov' in the ARNs. Note: the HeadBucket API used by the connectivity test is authorized by s3:ListBucket.",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "StratusScanS3BucketLevel",
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:ListBucket"
+      ],
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME"
+    },
+    {
+      "Sid": "StratusScanS3ObjectWrite",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:DeleteObject"
+      ],
+      "Resource": "arn:aws:s3:::YOUR-BUCKET-NAME/stratusscan/*"
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "stratusscancli-aws"
-version = "0.6.0-beta"
+version = "0.7.0-beta"
 description = "AWS defensive security scanning and auditing tool for resource exports"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/_resource_bundle.py
+++ b/scripts/_resource_bundle.py
@@ -80,70 +80,24 @@ def _detect_new_xlsx(
 def prompt_script_selection(
     category_name: str,
     scripts: list[tuple[str, str]],
-):
+) -> list[tuple[str, str]]:
     """
     Present a numbered multi-select menu for script selection.
 
-    Returns a list of selected (display_name, filename) tuples,
-    or the strings 'back' or 'exit'.
+    Returns the list of selected (display_name, filename) tuples. Navigation
+    is handled the single-voice way via utils.prompt_multiselect, which raises
+    BackSignal / ExitToMainSignal / QuitSignal for b / x / q.
     """
     # Auto-run mode: select everything without prompting
     if utils.is_auto_run():
         return list(scripts)
 
-    while True:
-        print(f"\nSELECT {category_name.upper()} TO EXPORT")
-        print("=" * 64)
-        print(f"   0. All  (export all {category_name.lower()})")
-        for i, (name, _) in enumerate(scripts, 1):
-            print(f"  {i:2d}. {name}")
-        print("=" * 64)
-        print("   b. Back    x. Exit")
-        print("=" * 64)
-
-        try:
-            raw = input(
-                "Enter number(s) separated by spaces (e.g. 1  or  1 3 5): "
-            ).strip().lower()
-        except KeyboardInterrupt:
-            print()
-            return 'exit'
-
-        if raw == 'b':
-            return 'back'
-        if raw == 'x':
-            return 'exit'
-        if raw == '0':
-            return list(scripts)
-
-        tokens = raw.split()
-        selected: list[tuple[str, str]] = []
-        seen: set = set()
-        valid = True
-
-        for tok in tokens:
-            try:
-                idx = int(tok)
-                if 1 <= idx <= len(scripts):
-                    if idx not in seen:
-                        selected.append(scripts[idx - 1])
-                        seen.add(idx)
-                else:
-                    print(
-                        f"  Invalid number {tok}. "
-                        f"Enter values between 0 and {len(scripts)}."
-                    )
-                    valid = False
-                    break
-            except ValueError:
-                print(f"  Invalid input '{tok}'. Please enter numbers only.")
-                valid = False
-                break
-
-        if valid and selected:
-            return selected
-        if valid and not selected:
-            print("  No scripts selected. Please enter at least one number.")
+    indices = utils.prompt_multiselect(
+        f"SELECT {category_name.upper()} TO EXPORT",
+        [name for name, _ in scripts],
+        all_label=f"All  (every {category_name.lower()} exporter)",
+    )
+    return [scripts[i - 1] for i in indices]
 
 
 # ---------------------------------------------------------------------------
@@ -309,7 +263,7 @@ def print_summary(
     print(f"{'=' * 70}")
 
     for r in results:
-        status = "✓" if r.success else "✗"
+        status = utils.GLYPH_OK if r.success else utils.GLYPH_FAIL
         print(f"  {status} {r.name:<35} {_fmt_duration(r.duration_seconds):>8}")
         if not r.success and r.error:
             print(f"      Error: {r.error}")
@@ -378,13 +332,13 @@ def run_bundle(
 
         # ── Step 2: Script selection ──────────────────────────────────────
         elif step == 2:
-            result = prompt_script_selection(category_name, scripts)
-            if result == 'back':
+            try:
+                selected_scripts = prompt_script_selection(category_name, scripts)
+            except utils.BackSignal:
                 step = 1
                 continue
-            if result == 'exit':
+            except (utils.ExitToMainSignal, utils.QuitSignal):
                 sys.exit(11)
-            selected_scripts = result
             step = 3
 
         # ── Step 3: Confirmation ──────────────────────────────────────────

--- a/scripts/billing_export.py
+++ b/scripts/billing_export.py
@@ -387,23 +387,39 @@ def main():
         if not utils.ensure_dependencies('pandas', 'openpyxl', 'dateutil'):
             sys.exit(1)
 
-        # Get user input for date range
+        # Get user input for date range — fully menu-driven (single-voice):
+        # "Last 12 months" plus the 12 most recent complete months, no free-text.
         if utils.is_auto_run():
             date_input = "last 12"
             _, _, start_date, end_date = validate_date_input(date_input)
         else:
-            while True:
-                date_input = input("\nWould you like the last 12 months (type \"last 12\") or a specific month (ex. \"01-2025\")? ")
-                is_valid, is_year_only, start_date, end_date = validate_date_input(date_input)
-                if is_valid:
-                    date_valid, message, _ = validate_date_range(start_date, end_date)
-                    if date_valid:
-                        break
-                    else:
-                        print(f"Error: {message}")
-                        print("Please try again with a more recent date range.")
-                else:
-                    print("Invalid input format. Please enter either \"last 12\" or a month in format \"MM-YYYY\" (e.g., \"01-2025\").")
+            today = datetime.datetime.now()
+            month_options = []  # (value "MM-YYYY", label "Month YYYY"), most recent first
+            y, m = today.year, today.month
+            for _ in range(12):
+                m -= 1
+                if m == 0:
+                    m, y = 12, y - 1
+                month_options.append(
+                    (f"{m:02d}-{y}", datetime.datetime(y, m, 1).strftime("%B %Y"))
+                )
+
+            menu_labels = ["Last 12 months"] + [label for _, label in month_options]
+            try:
+                choice = utils.prompt_menu("BILLING PERIOD", menu_labels)
+            except utils.BackSignal:
+                sys.exit(10)
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                sys.exit(11)
+
+            date_input = "last 12" if choice == 1 else month_options[choice - 2][0]
+            _, _, start_date, end_date = validate_date_input(date_input)
+
+            # Menu values are always well-formed; still guard the retention range.
+            date_valid, message, _ = validate_date_range(start_date, end_date)
+            if not date_valid:
+                print(f"{utils.GLYPH_FAIL} {message}")
+                sys.exit(1)
 
         # Get billing data
         billing_data = get_billing_data(start_date, end_date)

--- a/scripts/compute_optimizer_export.py
+++ b/scripts/compute_optimizer_export.py
@@ -763,15 +763,19 @@ def main():
             print("  - IAM role (if running on EC2)")
             return
 
-        # Check if Compute Optimizer is enabled
-        print("\n" + "="*70)
-        print("IMPORTANT: AWS Compute Optimizer must be opted-in to get recommendations.")
-        print("Visit the AWS Compute Optimizer console to enable it if not already enabled.")
-        print("="*70)
+        # Check if Compute Optimizer is enabled. This is a courtesy pre-flight
+        # gate for interactive users only — under AUTO_RUN (bundle / --run-all /
+        # --org-scan) we proceed and let the API surface a real failure via the
+        # fail-loud collection path, rather than silently skipping the export.
+        if not utils.is_auto_run():
+            print("\n" + "="*70)
+            print("IMPORTANT: AWS Compute Optimizer must be opted-in to get recommendations.")
+            print("Visit the AWS Compute Optimizer console to enable it if not already enabled.")
+            print("="*70)
 
-        if not utils.prompt_for_confirmation("Have you enabled Compute Optimizer?", default=False):
-            print("Please enable Compute Optimizer first, then run this script again.")
-            return
+            if not utils.prompt_for_confirmation("Have you enabled Compute Optimizer?", default=False):
+                print("Please enable Compute Optimizer first, then run this script again.")
+                return
 
         # Get recommendations for all regions. Region failures across any of
         # the five recommendation scopes are collected into failed_regions

--- a/scripts/ec2_export.py
+++ b/scripts/ec2_export.py
@@ -848,7 +848,7 @@ def main():
                 except utils.BackSignal:
                     step = 1
                     continue
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 instance_filter, filter_desc = result
                 step = 3

--- a/scripts/health_export.py
+++ b/scripts/health_export.py
@@ -154,26 +154,33 @@ def _run_export(account_id: str, account_name: str) -> None:
     region = 'us-east-1'
 
     # Ask user for time range
-    utils.log_info("\nSelect time range for health events:")
-    utils.log_info("  1. Last 7 days")
-    utils.log_info("  2. Last 30 days")
-    utils.log_info("  3. Last 90 days")
-    utils.log_info("  4. All events (warning: may be large)")
-
     if utils.is_auto_run():
-        choice = "1"
+        choice = 1
     else:
-        choice = input("\nEnter choice (1-4) [default: 1]: ").strip() or "1"
+        try:
+            choice = utils.prompt_menu(
+                "HEALTH EVENT TIME RANGE",
+                [
+                    "Last 7 days",
+                    "Last 30 days",
+                    "Last 90 days",
+                    "All events  (warning: may be large)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
 
     # Calculate time filter
     now = datetime.utcnow()
-    if choice == "1":
+    if choice == 1:
         start_time = now - timedelta(days=7)
         time_desc = "last 7 days"
-    elif choice == "2":
+    elif choice == 2:
         start_time = now - timedelta(days=30)
         time_desc = "last 30 days"
-    elif choice == "3":
+    elif choice == 3:
         start_time = now - timedelta(days=90)
         time_desc = "last 90 days"
     else:

--- a/scripts/iam_export.py
+++ b/scripts/iam_export.py
@@ -1726,7 +1726,7 @@ def main():
                     )
                 except utils.BackSignal:
                     sys.exit(10)
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 choice = result
                 step = 2
@@ -1745,7 +1745,7 @@ def main():
                     except utils.BackSignal:
                         step = 1
                         continue
-                    except utils.QuitSignal:
+                    except (utils.ExitToMainSignal, utils.QuitSignal):
                         sys.exit(11)
                     include_aws_managed = (result == 2)
                     step = 3

--- a/scripts/iam_identity_center_export.py
+++ b/scripts/iam_identity_center_export.py
@@ -2115,7 +2115,7 @@ def main():
                     )
                 except utils.BackSignal:
                     sys.exit(10)
-                except utils.QuitSignal:
+                except (utils.ExitToMainSignal, utils.QuitSignal):
                     sys.exit(11)
                 choice = result
                 step = 2

--- a/scripts/s3_export.py
+++ b/scripts/s3_export.py
@@ -662,71 +662,37 @@ def main():
         region_input = os.environ.get('AWS_REGION', 'all')
         target_region = None if region_input.lower() == 'all' else region_input
     else:
-        # Interactive mode: Display standardized region selection menu
-        print("\n" + "=" * 68)
-        print("REGION SELECTION")
-        print("=" * 68)
-        print()
-        print("Please select which AWS regions to scan:")
-        print()
-        print("1. Default Regions (recommended for most use cases)")
-        print(f"   └─ {example_regions}")
-        print()
-        print("2. All Available Regions")
-        print("   └─ Scans all regions (slower, more comprehensive)")
-        print()
-        print("3. Specific Region")
-        print("   └─ Choose a single region to scan")
-        print()
-
-        # Get user selection with validation
-        while True:
-            try:
-                selection = input("Enter your selection (1-3): ").strip()
-                selection_int = int(selection)
-                if 1 <= selection_int <= 3:
-                    break
-                else:
-                    print("Please enter a number between 1 and 3.")
-            except ValueError:
-                print("Please enter a valid number (1-3).")
-
-        # Get regions based on selection
+        # Interactive: single-voice region selection. S3 is global, so this is a
+        # single-region FILTER (or all regions) — not the multi-region
+        # utils.prompt_region_selection. prompt_menu gives consistent b/x/q nav.
         all_available_regions = utils.get_partition_regions(partition, all_regions=True)
+        try:
+            region_choice = utils.prompt_menu(
+                "REGION SELECTION",
+                [
+                    "Default Regions   (scan all regions for S3 buckets)",
+                    "All Available Regions",
+                    "Specific Region   (filter to a single region)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
 
-        # Process selection
-        if selection_int == 1:
-            # Default regions - for S3, scan all regions by default
+        if region_choice in (1, 2):
+            # S3 is global — both Default and All scan every region.
             target_region = None
-            utils.log_info("Scanning all regions for S3 buckets")
-        elif selection_int == 2:
-            # All regions
-            target_region = None
-            utils.log_info(f"Scanning all {len(all_available_regions)} AWS regions")
-        else:  # selection_int == 3
-            # Display numbered list of regions
-            print("\n" + "=" * 68)
-            print("AVAILABLE AWS REGIONS")
-            print("=" * 68)
-            print()
-            for idx, region in enumerate(all_available_regions, 1):
-                print(f"{idx:2}. {region}")
-            print()
-
-            # Get region selection with validation
-            while True:
-                try:
-                    region_num = input(f"Enter region number (1-{len(all_available_regions)}): ").strip()
-                    region_idx = int(region_num) - 1
-                    if 0 <= region_idx < len(all_available_regions):
-                        selected_region = all_available_regions[region_idx]
-                        target_region = selected_region
-                        utils.log_info(f"Scanning region: {selected_region}")
-                        break
-                    else:
-                        print(f"Please enter a number between 1 and {len(all_available_regions)}.")
-                except ValueError:
-                    print(f"Please enter a valid number (1-{len(all_available_regions)}).")
+            utils.log_info(f"Scanning all {len(all_available_regions)} AWS regions for S3 buckets")
+        else:
+            try:
+                region_idx = utils.prompt_menu("AVAILABLE AWS REGIONS", all_available_regions)
+            except utils.BackSignal:
+                sys.exit(10)
+            except (utils.ExitToMainSignal, utils.QuitSignal):
+                sys.exit(11)
+            target_region = all_available_regions[region_idx - 1]
+            utils.log_info(f"Scanning region: {target_region}")
 
     # Validate region if a specific one was provided
     if target_region and not is_valid_aws_region(target_region):

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -1345,18 +1345,28 @@ Examples:
 
     utils.log_info(f"AWS Account: {account_name} ({utils.mask_account_id(account_id)})")
 
-    # Detect partition for region examples
+    # Region selection — handle back/exit navigation (was previously ignored).
     regions = utils.prompt_region_selection()
+    if regions in ('back', 'exit'):
+        sys.exit(0)
 
     # Prompt for scan mode (skipped in auto-run — defaults to quick)
     if utils.is_auto_run():
         scan_mode = 'quick'
     else:
-        print("\n  Scan Mode:")
-        print("  [1] Quick Scan  — service presence and resource counts")
-        print("  [2] Deep Scan   — counts + asset breakdown (slower)")
-        mode_choice = input("  Enter choice [1]: ").strip() or "1"
-        scan_mode = 'deep' if mode_choice == '2' else 'quick'
+        try:
+            mode_choice = utils.prompt_menu(
+                "SCAN MODE",
+                [
+                    "Quick Scan  — service presence and resource counts",
+                    "Deep Scan   — counts + asset breakdown (slower)",
+                ],
+            )
+        except utils.BackSignal:
+            sys.exit(10)
+        except (utils.ExitToMainSignal, utils.QuitSignal):
+            sys.exit(11)
+        scan_mode = 'deep' if mode_choice == 2 else 'quick'
 
     # Discover services
     print(f"\nScanning {len(regions)} region(s) for services in use ({scan_mode} mode)...")

--- a/scripts/services_in_use_export.py
+++ b/scripts/services_in_use_export.py
@@ -1438,7 +1438,7 @@ Examples:
         print("="*60)
         print("SMART SCAN RECOMMENDATIONS")
         print("="*60)
-        print(f"✓ {recommendation_count} export scripts recommended")
+        print(f"{utils.GLYPH_OK} {recommendation_count} export scripts recommended")
         print("  └─ See 'Recommended Scripts' worksheet in Excel export")
         print()
         always_run = len([r for r in df_recommendations.to_dict('records') if r.get('Priority') == 'Always Run'])

--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -569,8 +569,8 @@ class ScriptExecutor:
             timestamp = datetime.now().strftime("%m.%d.%Y-%H%M")
             filename = f"smart-scan-execution-log-{timestamp}.txt"
 
-        log_path = utils.get_output_dir() / filename
         try:
+            log_path = utils.get_output_filepath(filename)
             with open(log_path, "w", encoding='utf-8') as f:
                 f.write("=" * 80 + "\n")
                 f.write(" " * 26 + "SMART SCAN EXECUTION LOG\n")
@@ -613,7 +613,7 @@ class ScriptExecutor:
             return True
 
         except Exception as e:
-            utils.log_error(f"Error saving execution log to {log_path}", e)
+            utils.log_error(f"Error saving execution log to {filename}", e)
             return False
 
 

--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -411,8 +411,8 @@ class ScriptExecutor:
 
         # Overall statistics
         print(f"Total Scripts:     {self.total_scripts}")
-        print(f"Successful:        {len(successful)} ✓")
-        print(f"Failed:            {len(failed)} ✗")
+        print(f"Successful:        {len(successful)} {utils.GLYPH_OK}")
+        print(f"Failed:            {len(failed)} {utils.GLYPH_FAIL}")
         print(f"Success Rate:      {(len(successful)/self.total_scripts*100):.1f}%")
         print(f"Total Time:        {total_minutes}m {total_seconds}s")
         print()
@@ -423,7 +423,7 @@ class ScriptExecutor:
             print("-" * 80)
             for result in successful:
                 output_info = f" → {result.output_file}" if result.output_file else ""
-                print(f"  ✓ {result.script:<45} {result.duration_formatted:>8}{output_info}")
+                print(f"  {utils.GLYPH_OK} {result.script:<45} {result.duration_formatted:>8}{output_info}")
             print()
 
         # Show failed scripts with error details
@@ -431,7 +431,7 @@ class ScriptExecutor:
             print("FAILED SCRIPTS:")
             print("-" * 80)
             for result in failed:
-                print(f"  ✗ {result.script:<45} {result.duration_formatted:>8}")
+                print(f"  {utils.GLYPH_FAIL} {result.script:<45} {result.duration_formatted:>8}")
                 if result.error_message:
                     # error_message is already truncated to 100 chars for console;
                     # full text is available in result.full_error_message
@@ -498,7 +498,7 @@ class ScriptExecutor:
                 self.results.append(result)
                 if show_progress:
                     self._show_progress(script_name)
-                    print(f"✗ Script not found: {script_name}")
+                    print(f"{utils.GLYPH_FAIL} Script not found: {script_name}")
                     print()
                 if session is not None:
                     utils.record_scan_result(

--- a/scripts/smart_scan/executor.py
+++ b/scripts/smart_scan/executor.py
@@ -72,8 +72,8 @@ class ScriptExecutor:
             regions: Regions to pass to subprocesses via STRATUSSCAN_REGIONS.
                      If None, subprocesses use their own configured defaults.
             show_output: When True, stream script stdout to console (prefixed with
-                         two spaces). When False, capture silently — for future TUI
-                         use where the TUI will consume the stream directly.
+                         two spaces). When False, capture silently for a caller
+                         that consumes the stream directly.
         """
         self.scripts = sorted(set(scripts))  # Deduplicate and sort for consistent ordering
 
@@ -635,7 +635,7 @@ def execute_scripts(
         save_log: Whether to save execution log to file
         regions: Regions to pass to subprocesses via STRATUSSCAN_REGIONS
         show_output: When True, stream script stdout to console in real time.
-                     When False, capture silently (for future TUI use).
+                     When False, capture silently for a caller that consumes it.
         session: Optional scan session dict from utils.start_scan_session().
                  When provided, results are persisted to disk after each script.
         skip_scripts: Optional set of script filenames to skip (already

--- a/scripts/smart_scan/mapping.py
+++ b/scripts/smart_scan/mapping.py
@@ -108,6 +108,7 @@ SERVICE_ALIASES: dict[str, str] = {
 
     # Management & Governance
     "cloudwatch": "Amazon CloudWatch",
+    "amazon cloudwatch logs": "Amazon CloudWatch",
     "cloudtrail": "AWS CloudTrail",
     "config": "AWS Config",
     "systems manager": "AWS Systems Manager",

--- a/scripts/smart_scan/selector.py
+++ b/scripts/smart_scan/selector.py
@@ -394,7 +394,7 @@ class SmartScanSelector:
                 f.write("=" * 80 + "\n")
 
             print()
-            print(f"✓ Checklist saved to: {filename}")
+            print(f"{utils.GLYPH_OK} Checklist saved to: {filename}")
             print()
             return True
 
@@ -426,7 +426,7 @@ class SmartScanSelector:
                 if selected:
                     # Show confirmation
                     print()
-                    print(f"✓ Selected {len(selected)} script(s)")
+                    print(f"{utils.GLYPH_OK} Selected {len(selected)} script(s)")
                     print()
                     confirm = questionary.confirm(
                         "Proceed with these scripts?", default=True, style=CUSTOM_STYLE
@@ -457,9 +457,46 @@ class SmartScanSelector:
                 return None
 
 
+def _plain_text_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
+    """
+    Plain-text fallback selector for when questionary is unavailable.
+
+    Mirrors the questionary flow's core action — choosing which recommended
+    scripts to run — using the shared utils.prompt_multiselect (stdlib only, so
+    it works in a bare CloudShell session). Returns the selected script set, or
+    None if the user backs out.
+    """
+    all_scripts = sorted(recommendations.get("all_scripts", set()))
+    if not all_scripts:
+        utils.log_warning("No recommended scripts to select.")
+        return None
+
+    stats = recommendations.get("coverage_stats", {})
+    print()
+    print("=" * 64)
+    print("  SMART SCAN — SELECT SCRIPTS TO RUN")
+    print("=" * 64)
+    print(f"  Services discovered: {stats.get('total_services_found', 0)}")
+    print(f"  Scripts recommended: {stats.get('total_scripts_recommended', 0)}")
+
+    try:
+        indices = utils.prompt_multiselect(
+            "RECOMMENDED SCRIPTS",
+            all_scripts,
+            all_label="All recommended scripts",
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
+        return None
+
+    return {all_scripts[i - 1] for i in indices}
+
+
 def interactive_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
     """
     Run interactive script selection.
+
+    Uses questionary's rich UI when available, otherwise falls back to a
+    plain-text multi-select (no silent "run everything" degradation).
 
     Args:
         recommendations: Recommendations dict from analyzer
@@ -468,11 +505,8 @@ def interactive_select(recommendations: dict[str, Any]) -> Optional[set[str]]:
         Set of selected scripts, or None if cancelled
     """
     if not QUESTIONARY_AVAILABLE:
-        utils.log_error(
-            "Interactive selection requires questionary library. "
-            "Install it with: pip install questionary>=2.0.0"
-        )
-        return None
+        utils.log_info("questionary not installed — using plain-text selection.")
+        return _plain_text_select(recommendations)
 
     selector = SmartScanSelector(recommendations)
     return selector.run_interactive()

--- a/scripts/smart_scan/selector.py
+++ b/scripts/smart_scan/selector.py
@@ -354,7 +354,10 @@ class SmartScanSelector:
             filename = f"smart-scan-checklist-{timestamp}.txt"
 
         try:
-            with open(filename, "w", encoding='utf-8') as f:
+            # Write into output/ alongside every other artifact, with the same
+            # containment check the exporters use (CWE-73).
+            checklist_path = utils.get_output_filepath(filename)
+            with open(checklist_path, "w", encoding='utf-8') as f:
                 f.write("=" * 80 + "\n")
                 f.write(" " * 28 + "SMART SCAN CHECKLIST\n")
                 f.write("=" * 80 + "\n\n")
@@ -394,7 +397,7 @@ class SmartScanSelector:
                 f.write("=" * 80 + "\n")
 
             print()
-            print(f"{utils.GLYPH_OK} Checklist saved to: {filename}")
+            print(f"{utils.GLYPH_OK} Checklist saved to: {checklist_path}")
             print()
             return True
 

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -480,7 +480,7 @@ def _print_crosscheck_summary(result: Optional[dict[str, Any]]) -> None:
         if len(not_collected) > 10:
             print(f"      ... and {len(not_collected) - 10} more (see report)")
     else:
-        print("  ✓ Every billed service was discovered.")
+        print(f"  {utils.GLYPH_OK} Every billed service was discovered.")
     if unmapped:
         print(f"  • {len(unmapped)} billed service(s) could not be mapped (see report).")
     print("  ─────────────────────────────────────────────────────────────")

--- a/smart_scan.py
+++ b/smart_scan.py
@@ -68,18 +68,18 @@ except ImportError as exc:
 
 
 def _prompt_scan_mode() -> str:
-    """Prompt user for Quick or Deep scan mode. Exits on b/x."""
-    print()
-    print("  ─── SCAN MODE ───────────────────────────────────────────────")
-    print("  [1] Quick Scan  — discover services, save a report, done")
-    print("  [2] Deep Scan   — discover services, then run export scripts")
-    print("  ─────────────────────────────────────────────────────────────")
-    print("  [B] Back    [X] Exit")
-    print("  ─────────────────────────────────────────────────────────────")
-    choice = input("  Enter choice [1]: ").strip().lower() or "1"
-    if choice in ('b', 'x'):
+    """Prompt user for Quick or Deep scan mode. Exits on b/x/q."""
+    try:
+        choice = utils.prompt_menu(
+            "SCAN MODE",
+            [
+                "Quick Scan  — discover services, save a report, done",
+                "Deep Scan   — discover services, then run export scripts",
+            ],
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
         sys.exit(0)
-    return 'deep' if choice == '2' else 'quick'
+    return 'deep' if choice == 2 else 'quick'
 
 
 def _format_detail(detail: dict[str, int]) -> str:
@@ -616,27 +616,31 @@ def main() -> None:
         return
 
     print()
-    print("  ─── RUN SCRIPTS ─────────────────────────────────────────────")
     print(f"  {n_scripts} export scripts are recommended for this account.")
-    print("  [Y] Run all recommended scripts now")
-    print("  [N] Exit — report saved, run scripts later")
-    print("  [C] Customize — choose specific scripts to run")
-    print("  ─────────────────────────────────────────────────────────────")
-    choice = input("  Enter choice [Y/N/C] (default N): ").strip().upper() or "N"
+    try:
+        gate = utils.prompt_menu(
+            "RUN SCRIPTS",
+            [
+                "Run all recommended scripts now",
+                "Exit — report saved, run scripts later",
+                "Customize — choose specific scripts to run",
+            ],
+        )
+    except (utils.BackSignal, utils.ExitToMainSignal, utils.QuitSignal):
+        utils.log_info("Exiting. Reports saved.")
+        return
 
-    if choice == 'N':
+    if gate == 2:
         utils.log_info("Exiting. Reports saved.")
         return
 
     selected_scripts = recommendations.get('all_scripts', set())
 
-    if choice == 'C':
+    if gate == 3:
+        # interactive_select handles the questionary / plain-text fallback itself.
         try:
-            from smart_scan.selector import QUESTIONARY_AVAILABLE, interactive_select
-            if QUESTIONARY_AVAILABLE:
-                selected_scripts = interactive_select(recommendations) or set()
-            else:
-                utils.log_warning("questionary not installed — running all recommended scripts")
+            from smart_scan.selector import interactive_select
+            selected_scripts = interactive_select(recommendations) or set()
         except ImportError:
             utils.log_warning("Selector unavailable — running all recommended scripts")
 
@@ -658,10 +662,10 @@ def main() -> None:
         prev = interrupted_smart[0]
         n_done = len(prev.get("results", []))
         n_total = len(prev.get("planned", []))
-        ans = input(
-            f"  Resume interrupted smart scan? ({n_done}/{n_total} scripts done) [y/n]: "
-        ).strip().lower()
-        if ans == "y":
+        if utils.prompt_for_confirmation(
+            f"Resume interrupted smart scan? ({n_done}/{n_total} scripts done)",
+            default=False,
+        ):
             utils.resume_scan_session(prev)
             session = prev
             done_keys = {r["key"] for r in prev.get("results", []) if r.get("status") == "success"}

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -1257,6 +1257,146 @@ def navigate_menus():
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
+def _run_full_audit(regions_arg, output) -> None:
+    """
+    Headless full-audit run: execute every exporter non-interactively, write a
+    per-run manifest, then build and deliver a spreadsheet run report.
+
+    This is the command the scheduled CodeBuild runner invokes:
+        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
+
+    Args:
+        regions_arg: Comma-separated region string, or None for exporter defaults.
+        output: 'local', 's3', or None to honour the configured destination.
+
+    Exits the process: 1 on credential failure or zero successful exporters,
+    2 on an --output s3 request with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — full audit run")
+    print("=" * 60)
+
+    # 1. Credentials
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Full audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Account: {account_name} ({account_id})")
+
+    # 2. Regions
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+
+    # 3. Output destination — the flag is authoritative over config for this run
+    #    and for every exporter subprocess (inherited via os.environ).
+    if output:
+        os.environ["STRATUSSCAN_OUTPUT_DESTINATION"] = output
+    destination = utils.resolve_s3_destination()
+    if destination["enabled"]:
+        print(f"  Output: s3://{destination['bucket']}/{destination['prefix']}")
+    elif output == "s3":
+        utils.log_error("Full audit: --output s3 requested but no S3 bucket is configured")
+        print("  [x] --output s3 requires a bucket (config output_settings.s3.bucket")
+        print("      or the STRATUSSCAN_S3_BUCKET env var).")
+        sys.exit(2)
+    else:
+        print(f"  Output: local ({utils.get_output_dir()})")
+
+    # 4. Exporters — every *_export.py on disk
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Full audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+    total = len(exporters)
+    print(f"  Exporters: {total}")
+    print("=" * 60)
+
+    # 5. Fresh per-run manifest (children append; parent reads it afterward)
+    run_ts = utils.get_export_date()
+    manifest_path = utils.get_output_dir() / f"{account_name}-audit-run-manifest-{run_ts}.jsonl"
+    try:
+        if manifest_path.exists():
+            manifest_path.unlink()
+    except OSError:
+        pass
+
+    # 6. Run each exporter sequentially. Sequential is deliberate: parallel
+    #    subprocesses multiply API throttling and interleave logs — both bad for
+    #    evidence integrity. A failure never aborts the run; it lands in the report.
+    results = []
+    run_start = time.monotonic()
+    for idx, script_path in enumerate(exporters, 1):
+        name = script_path.name
+        print(f"\n[{idx}/{total}] {name}")
+
+        child_env = os.environ.copy()
+        child_env["STRATUSSCAN_AUTO_RUN"] = "1"
+        child_env["STRATUSSCAN_RUN_MANIFEST"] = str(manifest_path)
+        child_env["STRATUSSCAN_CURRENT_EXPORTER"] = name
+        child_env["STRATUSSCAN_ACCOUNT_ID"] = account_id or ""
+        child_env["STRATUSSCAN_ACCOUNT_NAME"] = account_name or ""
+        if regions:
+            child_env["STRATUSSCAN_REGIONS"] = ",".join(regions)
+
+        start = time.monotonic()
+        return_code = 0
+        error_message = None
+        try:
+            proc = subprocess.run([sys.executable, str(script_path)], env=child_env, timeout=1800)
+            return_code = proc.returncode
+        except subprocess.TimeoutExpired:
+            return_code, error_message = -1, "timed out (30 min)"
+            utils.log_error("Full audit: %s timed out", name)
+        except Exception as exc:  # noqa: BLE001
+            return_code, error_message = -1, str(exc)
+            utils.log_error("Full audit: %s error: %s", name, exc)
+
+        duration = time.monotonic() - start
+        results.append({
+            "script": name,
+            "success": return_code == 0,
+            "return_code": return_code,
+            "duration_seconds": duration,
+            "error_message": error_message,
+        })
+        print(f"      {'done' if return_code == 0 else 'FAILED'} ({duration:.0f}s)")
+
+    run_duration = time.monotonic() - run_start
+
+    # 7. Build + deliver the run report (delivers per destination; never empty,
+    #    so it is never suppressed). STRATUSSCAN_RUN_MANIFEST is intentionally
+    #    NOT set in this parent process, so the report does not record itself.
+    manifest_records = utils.read_run_manifest(str(manifest_path))
+    report_df = utils.build_run_report_dataframe(results, manifest_records)
+    report_filename = utils.create_export_filename(account_name, "audit-run-report")
+    report_location = utils.save_dataframe_to_excel(report_df, report_filename, sheet_name="Run Report")
+
+    # 8. Summary
+    counts = {}
+    if not report_df.empty:
+        counts = report_df["Status"].value_counts().to_dict()
+    n_ok = counts.get(utils.RUN_STATUS_OK, 0)
+    n_empty = counts.get(utils.RUN_STATUS_EMPTY, 0)
+    n_none = counts.get(utils.RUN_STATUS_NO_OUTPUT, 0)
+    n_failed = counts.get(utils.RUN_STATUS_FAILED, 0)
+    total_assets = int(report_df["Assets"].sum()) if not report_df.empty else 0
+
+    print("\n" + "=" * 60)
+    print("FULL AUDIT COMPLETE")
+    print("=" * 60)
+    print(f"  Exporters run : {total}  ({int(run_duration)}s total)")
+    print(f"  With data     : {n_ok}  ({total_assets} assets)")
+    print(f"  Empty (0)     : {n_empty}")
+    print(f"  No output     : {n_none}")
+    print(f"  Failed        : {n_failed}")
+    print(f"  Run report    : {report_location}")
+    print("=" * 60)
+
+    sys.exit(0 if results and n_ok > 0 else 1)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="stratusscan",
@@ -1275,6 +1415,22 @@ def _build_parser() -> argparse.ArgumentParser:
         "--verbose",
         action="store_true",
         help="enable debug-level console output",
+    )
+    parser.add_argument(
+        "--run-all",
+        action="store_true",
+        help="run every exporter non-interactively (headless full audit) and write a run report",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["local", "s3"],
+        default=None,
+        help="output destination for --run-all (overrides config; default: configured destination)",
+    )
+    parser.add_argument(
+        "--regions",
+        default=None,
+        help="comma-separated regions for --run-all (e.g. us-east-1,us-west-2)",
     )
     return parser
 
@@ -1329,6 +1485,10 @@ def main():
     if args.dry_run:
         _run_dry_run()
         return  # sys.exit(0) called inside, but be explicit
+
+    if args.run_all:
+        _run_full_audit(args.regions, args.output)
+        return  # sys.exit() called inside
 
     try:
         utils.log_section("STARTING MAIN MENU NAVIGATION")

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -207,9 +207,7 @@ def install_dependency(dependency):
         bool: True if installed successfully, False otherwise
     """
     print(f"\nPackage '{dependency}' is required but not installed.")
-    response = input(f"Would you like to install {dependency}? (y/n): ").lower()
-
-    if response == 'y':
+    if utils.prompt_for_confirmation(f"Would you like to install {dependency}?", default=False):
         try:
             import subprocess
             print(f"Installing {dependency}...")
@@ -1006,32 +1004,27 @@ def _show_session_detail(session: dict) -> None:
 def show_scan_history() -> None:
     """Display recent scan sessions and allow drilling into details."""
     sessions = utils.load_scan_sessions(10)
-    SEP = "─" * 70
-    print(f"\nSCAN HISTORY (last {len(sessions)} sessions)")
-    print(SEP)
-
     if not sessions:
+        print("\nSCAN HISTORY")
+        print("─" * 70)
         print("  No scan sessions found.")
         input("\nPress Enter to return...")
         return
 
-    for idx, s in enumerate(sessions, 1):
+    options = []
+    for s in sessions:
         n_done = len(s.get("results", []))
         n_total = len(s.get("planned", []))
         status = s.get("status", "?")
         icon = "✅" if status == "completed" else ("⚠ " if status == "running" else "?")
         ts = s.get("started_at", "")[:16].replace("T", " ")
-        print(f"  [{idx}] {icon} {s.get('label', s.get('scan_type'))} — {n_done}/{n_total} | {ts}")
+        options.append(f"{icon} {s.get('label', s.get('scan_type'))} — {n_done}/{n_total} | {ts}")
 
-    print(SEP)
-    print("  [#] View session details    [B] Back")
-    choice = input("\nSelect: ").strip().upper()
-    if choice == "B" or not choice:
+    try:
+        choice = utils.prompt_menu(f"SCAN HISTORY (last {len(sessions)} sessions)", options)
+    except (BackSignal, ExitToMainSignal, QuitSignal):
         return
-    if choice.isdigit():
-        idx = int(choice) - 1
-        if 0 <= idx < len(sessions):
-            _show_session_detail(sessions[idx])
+    _show_session_detail(sessions[choice - 1])
 
 
 def _resume_org_scan_from_session(session: dict) -> None:
@@ -1072,8 +1065,9 @@ def _resume_org_scan_from_session(session: dict) -> None:
         input("  Press Enter to return to menu...")
         return
 
-    confirm = input(f"\n  Run {script_name} across {n_remaining} remaining account(s)? (y/n): ").strip().lower()
-    if confirm != "y":
+    if not utils.prompt_for_confirmation(
+        f"\n  Run {script_name} across {n_remaining} remaining account(s)?", default=False
+    ):
         return
 
     utils.resume_scan_session(session)
@@ -1137,18 +1131,21 @@ def _startup_interrupted_check() -> None:
     print(f"  {label}")
     print(f"  Started: {ts}  |  Completed: {n_done}/{n_total}")
     print(f"  {SEP}")
-    print("  [Y] Resume now")
-    print("  [N] Skip — go to main menu")
-    print("  [H] View scan history")
     print(f"  {SEP}")
 
-    choice = input("\n  Choice [Y/N/H]: ").strip().upper() or "N"
+    try:
+        choice = utils.prompt_menu(
+            "RESUME INTERRUPTED SCAN?",
+            ["Resume now", "Skip — go to main menu", "View scan history"],
+        )
+    except (BackSignal, ExitToMainSignal, QuitSignal):
+        return
 
-    if choice == "H":
+    if choice == 3:
         show_scan_history()
         return
 
-    if choice != "Y":
+    if choice != 1:
         return
 
     if scan_type == "org-scan":
@@ -1161,7 +1158,7 @@ def _startup_interrupted_check() -> None:
         subprocess.run([sys.executable, str(smart_scan_path)], env=child_env)
         input("\n  Press Enter to return to menu...")
     else:
-        print(f"\n  ❌ Unknown scan type '{scan_type}' — use [H] Scan History to view details.")
+        print(f"\n  ❌ Unknown scan type '{scan_type}' — use Scan History to view details.")
         input("  Press Enter to return to menu...")
 
 

--- a/stratusscan.py
+++ b/stratusscan.py
@@ -1257,79 +1257,66 @@ def navigate_menus():
     except Exception as e:
         print(f"An unexpected error occurred: {e}")
 
-def _run_full_audit(regions_arg, output) -> None:
+def _safe_label(name) -> str:
+    """Sanitise an account name for use in a filename (alnum, dot, dash, underscore)."""
+    import re
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", (name or "").strip()).strip("-") or "account"
+
+
+def _resolve_audit_destination(output):
     """
-    Headless full-audit run: execute every exporter non-interactively, write a
-    per-run manifest, then build and deliver a spreadsheet run report.
-
-    This is the command the scheduled CodeBuild runner invokes:
-        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
-
-    Args:
-        regions_arg: Comma-separated region string, or None for exporter defaults.
-        output: 'local', 's3', or None to honour the configured destination.
-
-    Exits the process: 1 on credential failure or zero successful exporters,
-    2 on an --output s3 request with no bucket, 0 otherwise.
+    Apply the --output flag (authoritative over config for this run and every
+    exporter subprocess), print the resolved destination, and return it.
+    Exits 2 if --output s3 was requested with no bucket configured.
     """
-    print("\nStratusScanCLI-AWS — full audit run")
-    print("=" * 60)
-
-    # 1. Credentials
-    ok, account_id, account_name = utils.validate_aws_credentials()
-    if not ok:
-        utils.log_error("Full audit: AWS credentials not found or invalid")
-        print("  [x] AWS credentials: not found or invalid")
-        sys.exit(1)
-    print(f"  Account: {account_name} ({account_id})")
-
-    # 2. Regions
-    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
-    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
-
-    # 3. Output destination — the flag is authoritative over config for this run
-    #    and for every exporter subprocess (inherited via os.environ).
     if output:
         os.environ["STRATUSSCAN_OUTPUT_DESTINATION"] = output
     destination = utils.resolve_s3_destination()
     if destination["enabled"]:
         print(f"  Output: s3://{destination['bucket']}/{destination['prefix']}")
     elif output == "s3":
-        utils.log_error("Full audit: --output s3 requested but no S3 bucket is configured")
+        utils.log_error("Audit: --output s3 requested but no S3 bucket is configured")
         print("  [x] --output s3 requires a bucket (config output_settings.s3.bucket")
         print("      or the STRATUSSCAN_S3_BUCKET env var).")
         sys.exit(2)
     else:
         print(f"  Output: local ({utils.get_output_dir()})")
+    return destination
 
-    # 4. Exporters — every *_export.py on disk
-    scripts_dir = utils.get_scripts_dir()
-    exporters = sorted(scripts_dir.glob("*_export.py"))
-    if not exporters:
-        utils.log_error("Full audit: no exporter scripts found")
-        print("  [x] No exporter scripts found.")
-        sys.exit(1)
-    total = len(exporters)
-    print(f"  Exporters: {total}")
-    print("=" * 60)
 
-    # 5. Fresh per-run manifest (children append; parent reads it afterward)
-    run_ts = utils.get_export_date()
-    manifest_path = utils.get_output_dir() / f"{account_name}-audit-run-manifest-{run_ts}.jsonl"
+def _audit_counts(report_df) -> dict:
+    """Tally per-status counts and total assets from a run-report DataFrame."""
+    counts = report_df["Status"].value_counts().to_dict() if not report_df.empty else {}
+    return {
+        "ok": counts.get(utils.RUN_STATUS_OK, 0),
+        "empty": counts.get(utils.RUN_STATUS_EMPTY, 0),
+        "no_output": counts.get(utils.RUN_STATUS_NO_OUTPUT, 0),
+        "failed": counts.get(utils.RUN_STATUS_FAILED, 0),
+        "total_assets": int(report_df["Assets"].sum()) if not report_df.empty else 0,
+    }
+
+
+def _run_exporters_for_account(exporters, account_id, account_name, regions, role_arn, manifest_path) -> list:
+    """
+    Run every exporter once for a single account, optionally via an assumed role.
+
+    Sequential by design: parallel subprocesses multiply API throttling and
+    interleave logs — both bad for evidence integrity. A failed exporter never
+    aborts the run; it lands in the report. Returns a list of per-exporter
+    result dicts (script, success, return_code, duration_seconds, error_message).
+    """
+    # Fresh manifest for this account (children append; parent reads it after).
     try:
         if manifest_path.exists():
             manifest_path.unlink()
     except OSError:
         pass
 
-    # 6. Run each exporter sequentially. Sequential is deliberate: parallel
-    #    subprocesses multiply API throttling and interleave logs — both bad for
-    #    evidence integrity. A failure never aborts the run; it lands in the report.
     results = []
-    run_start = time.monotonic()
+    total = len(exporters)
     for idx, script_path in enumerate(exporters, 1):
         name = script_path.name
-        print(f"\n[{idx}/{total}] {name}")
+        print(f"  [{idx}/{total}] {name}")
 
         child_env = os.environ.copy()
         child_env["STRATUSSCAN_AUTO_RUN"] = "1"
@@ -1339,6 +1326,8 @@ def _run_full_audit(regions_arg, output) -> None:
         child_env["STRATUSSCAN_ACCOUNT_NAME"] = account_name or ""
         if regions:
             child_env["STRATUSSCAN_REGIONS"] = ",".join(regions)
+        if role_arn:
+            child_env["STRATUSSCAN_ROLE_ARN"] = role_arn
 
         start = time.monotonic()
         return_code = 0
@@ -1348,10 +1337,10 @@ def _run_full_audit(regions_arg, output) -> None:
             return_code = proc.returncode
         except subprocess.TimeoutExpired:
             return_code, error_message = -1, "timed out (30 min)"
-            utils.log_error("Full audit: %s timed out", name)
+            utils.log_error(f"Audit: {name} timed out (account {account_id})")
         except Exception as exc:  # noqa: BLE001
             return_code, error_message = -1, str(exc)
-            utils.log_error("Full audit: %s error: %s", name, exc)
+            utils.log_error(f"Audit: {name} error (account {account_id})", exc)
 
         duration = time.monotonic() - start
         results.append({
@@ -1361,40 +1350,195 @@ def _run_full_audit(regions_arg, output) -> None:
             "duration_seconds": duration,
             "error_message": error_message,
         })
-        print(f"      {'done' if return_code == 0 else 'FAILED'} ({duration:.0f}s)")
+    return results
 
-    run_duration = time.monotonic() - run_start
 
-    # 7. Build + deliver the run report (delivers per destination; never empty,
-    #    so it is never suppressed). STRATUSSCAN_RUN_MANIFEST is intentionally
-    #    NOT set in this parent process, so the report does not record itself.
+def _build_and_deliver_report(results, manifest_path, account_label):
+    """Build the run report from results + manifest and deliver it. Returns
+    (report_df, report_location)."""
     manifest_records = utils.read_run_manifest(str(manifest_path))
     report_df = utils.build_run_report_dataframe(results, manifest_records)
-    report_filename = utils.create_export_filename(account_name, "audit-run-report")
+    report_filename = utils.create_export_filename(account_label, "audit-run-report")
     report_location = utils.save_dataframe_to_excel(report_df, report_filename, sheet_name="Run Report")
+    return report_df, report_location
 
-    # 8. Summary
-    counts = {}
-    if not report_df.empty:
-        counts = report_df["Status"].value_counts().to_dict()
-    n_ok = counts.get(utils.RUN_STATUS_OK, 0)
-    n_empty = counts.get(utils.RUN_STATUS_EMPTY, 0)
-    n_none = counts.get(utils.RUN_STATUS_NO_OUTPUT, 0)
-    n_failed = counts.get(utils.RUN_STATUS_FAILED, 0)
-    total_assets = int(report_df["Assets"].sum()) if not report_df.empty else 0
+
+def _run_full_audit(regions_arg, output) -> None:
+    """
+    Headless single-account full-audit run: execute every exporter
+    non-interactively, write a per-run manifest, then build and deliver a
+    spreadsheet run report.
+
+        stratusscan --run-all --output s3 --regions us-east-1,us-west-2
+
+    Exits: 1 on credential failure or zero successful exporters, 2 on
+    --output s3 with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — full audit run")
+    print("=" * 60)
+
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Full audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Account: {account_name} ({account_id})")
+
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+
+    _resolve_audit_destination(output)
+
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Full audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+    print(f"  Exporters: {len(exporters)}")
+    print("=" * 60)
+
+    run_ts = utils.get_export_date()
+    label = _safe_label(account_name)
+    manifest_path = utils.get_output_dir() / f"{label}-audit-run-manifest-{run_ts}.jsonl"
+
+    run_start = time.monotonic()
+    results = _run_exporters_for_account(exporters, account_id, account_name, regions, None, manifest_path)
+    run_duration = time.monotonic() - run_start
+
+    report_df, report_location = _build_and_deliver_report(results, manifest_path, label)
+    c = _audit_counts(report_df)
 
     print("\n" + "=" * 60)
     print("FULL AUDIT COMPLETE")
     print("=" * 60)
-    print(f"  Exporters run : {total}  ({int(run_duration)}s total)")
-    print(f"  With data     : {n_ok}  ({total_assets} assets)")
-    print(f"  Empty (0)     : {n_empty}")
-    print(f"  No output     : {n_none}")
-    print(f"  Failed        : {n_failed}")
+    print(f"  Exporters run : {len(exporters)}  ({int(run_duration)}s total)")
+    print(f"  With data     : {c['ok']}  ({c['total_assets']} assets)")
+    print(f"  Empty (0)     : {c['empty']}")
+    print(f"  No output     : {c['no_output']}")
+    print(f"  Failed        : {c['failed']}")
     print(f"  Run report    : {report_location}")
     print("=" * 60)
 
-    sys.exit(0 if results and n_ok > 0 else 1)
+    sys.exit(0 if results and c["ok"] > 0 else 1)
+
+
+def _run_org_audit(regions_arg, output, scan_role, exclude_arg) -> None:
+    """
+    Headless organization-wide audit: from the audit account, enumerate every
+    active org account, assume the uniformly-named read-only scan role in each,
+    run the full exporter set, deliver a per-account run report, then deliver an
+    org-level summary rolling up every account.
+
+        stratusscan --org-scan --scan-role StratusScanReadOnly --output s3 --regions us-east-1
+
+    Accounts whose scan role cannot be assumed are skipped and recorded as
+    ROLE FAILED in the summary (the StackSet may still be rolling out) — the run
+    is not aborted. Exits: 1 on credential / enumeration failure or zero
+    accounts scanned, 2 on --output s3 with no bucket, 0 otherwise.
+    """
+    print("\nStratusScanCLI-AWS — organization audit run")
+    print("=" * 60)
+
+    ok, account_id, account_name = utils.validate_aws_credentials()
+    if not ok:
+        utils.log_error("Org audit: AWS credentials not found or invalid")
+        print("  [x] AWS credentials: not found or invalid")
+        sys.exit(1)
+    print(f"  Audit account: {account_name} ({account_id})")
+
+    regions = [r.strip() for r in regions_arg.split(",") if r.strip()] if regions_arg else None
+    print(f"  Regions: {', '.join(regions) if regions else 'exporter defaults'}")
+    print(f"  Scan role: {scan_role}")
+
+    _resolve_audit_destination(output)
+    partition = utils.detect_partition()
+
+    scripts_dir = utils.get_scripts_dir()
+    exporters = sorted(scripts_dir.glob("*_export.py"))
+    if not exporters:
+        utils.log_error("Org audit: no exporter scripts found")
+        print("  [x] No exporter scripts found.")
+        sys.exit(1)
+
+    # Enumerate the organization from the audit account.
+    try:
+        accounts = utils.list_organization_accounts(active_only=True)
+    except Exception as exc:  # noqa: BLE001
+        utils.log_error("Org audit: organizations:ListAccounts failed", exc)
+        print(f"  [x] Could not list organization accounts: {exc}")
+        print("      The audit account needs Organizations read access (management or")
+        print("      delegated administrator).")
+        sys.exit(1)
+
+    exclude = {a.strip() for a in exclude_arg.split(",") if a.strip()} if exclude_arg else set()
+    accounts = [a for a in accounts if a["id"] not in exclude]
+    if not accounts:
+        print("  [x] No active accounts to scan.")
+        sys.exit(1)
+    print(f"  Accounts: {len(accounts)} active" + (f"  ({len(exclude)} excluded)" if exclude else ""))
+    print(f"  Exporters: {len(exporters)} per account")
+    print("=" * 60)
+
+    run_ts = utils.get_export_date()
+    summaries = []
+    n_scanned = 0
+    org_start = time.monotonic()
+
+    for i, acct in enumerate(accounts, 1):
+        aid = acct["id"]
+        aname = acct["name"] or aid
+        print(f"\n[account {i}/{len(accounts)}] {aname} ({aid})")
+
+        role_arn = utils.build_arn("iam", f"role/{scan_role}", region="", account_id=aid, partition=partition)
+        assumable, err = utils.verify_assume_role(role_arn, regions[0] if regions else None)
+        if not assumable:
+            print(f"  [skip] cannot assume {role_arn}")
+            print(f"         {err}")
+            utils.log_error(f"Org audit: assume-role failed for {aid}: {err}")
+            summaries.append({
+                "account_id": aid, "account_name": aname,
+                "status": utils.ACCOUNT_STATUS_ROLE_FAILED,
+                "exporters": 0, "ok": 0, "empty": 0, "no_output": 0, "failed": 0,
+                "total_assets": 0, "report": "", "detail": (err or "")[:300],
+            })
+            continue
+
+        label = f"{_safe_label(aname)}-{aid}"
+        manifest_path = utils.get_output_dir() / f"{label}-audit-run-manifest-{run_ts}.jsonl"
+        results = _run_exporters_for_account(exporters, aid, aname, regions, role_arn, manifest_path)
+        report_df, report_loc = _build_and_deliver_report(results, manifest_path, label)
+        c = _audit_counts(report_df)
+        n_scanned += 1
+        summaries.append({
+            "account_id": aid, "account_name": aname,
+            "status": utils.ACCOUNT_STATUS_SCANNED,
+            "exporters": len(results), "ok": c["ok"], "empty": c["empty"],
+            "no_output": c["no_output"], "failed": c["failed"],
+            "total_assets": c["total_assets"], "report": report_loc or "", "detail": "",
+        })
+        print(f"  done — {c['ok']} with data, {c['total_assets']} assets, {c['failed']} failed")
+
+    org_duration = time.monotonic() - org_start
+
+    # Org-level summary roll-up — the top-level index over per-account reports.
+    summary_df = utils.build_org_summary_dataframe(summaries)
+    summary_filename = utils.create_export_filename(f"{_safe_label(account_name)}-ORG", "org-audit-summary")
+    summary_loc = utils.save_dataframe_to_excel(summary_df, summary_filename, sheet_name="Org Summary")
+
+    n_role_failed = sum(1 for s in summaries if s["status"] == utils.ACCOUNT_STATUS_ROLE_FAILED)
+    total_assets = sum(s["total_assets"] for s in summaries)
+
+    print("\n" + "=" * 60)
+    print("ORGANIZATION AUDIT COMPLETE")
+    print("=" * 60)
+    print(f"  Accounts        : {len(accounts)}  ({int(org_duration)}s total)")
+    print(f"  Scanned         : {n_scanned}  ({total_assets} assets)")
+    print(f"  Role failed     : {n_role_failed}")
+    print(f"  Org summary     : {summary_loc}")
+    print("=" * 60)
+
+    sys.exit(0 if n_scanned > 0 else 1)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -1431,6 +1575,23 @@ def _build_parser() -> argparse.ArgumentParser:
         "--regions",
         default=None,
         help="comma-separated regions for --run-all (e.g. us-east-1,us-west-2)",
+    )
+    parser.add_argument(
+        "--org-scan",
+        action="store_true",
+        help="run the full audit across every active account in the AWS Organization (requires --scan-role)",
+    )
+    parser.add_argument(
+        "--scan-role",
+        default=None,
+        metavar="NAME",
+        help="name of the read-only role to assume in each org account (with --org-scan)",
+    )
+    parser.add_argument(
+        "--exclude-accounts",
+        default=None,
+        metavar="IDS",
+        help="comma-separated account IDs to skip during --org-scan",
     )
     return parser
 
@@ -1485,6 +1646,13 @@ def main():
     if args.dry_run:
         _run_dry_run()
         return  # sys.exit(0) called inside, but be explicit
+
+    if args.org_scan:
+        if not args.scan_role:
+            print("--org-scan requires --scan-role <name> (the role to assume in each account)")
+            sys.exit(2)
+        _run_org_audit(args.regions, args.output, args.scan_role, args.exclude_accounts)
+        return  # sys.exit() called inside
 
     if args.run_all:
         _run_full_audit(args.regions, args.output)

--- a/tests/smart_scan/test_executor.py
+++ b/tests/smart_scan/test_executor.py
@@ -274,19 +274,36 @@ class TestExecutionFlow:
             assert isinstance(summary, dict)
             assert "total" in summary
 
-    def test_save_execution_log(self):
-        """Test saving execution log to file."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            executor = ScriptExecutor({"test.py"})
+    def test_save_execution_log(self, tmp_path, monkeypatch):
+        """The execution log is written into the output directory, never to a
+        caller-supplied location outside it (CWE-73)."""
+        import utils
 
-            log_file = Path(tmpdir) / "test-execution.log"
-            result = executor.save_execution_log(str(log_file))
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
 
-            # Should return True even if no results (empty log)
-            assert isinstance(result, bool)
+        assert executor.save_execution_log("test-execution.log") is True
+        assert (tmp_path / "test-execution.log").exists()
 
-            if result:
-                assert log_file.exists()
+    def test_save_execution_log_contains_traversal(self, tmp_path, monkeypatch):
+        """A traversing filename is reduced to a bare name inside output/."""
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
+
+        assert executor.save_execution_log("../../escaped.log") is True
+        assert (tmp_path / "escaped.log").exists()
+        assert not (tmp_path.parent.parent / "escaped.log").exists()
+
+    def test_save_execution_log_rejects_unusable_name(self, tmp_path, monkeypatch):
+        """A name with no usable component returns False rather than raising."""
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        executor = ScriptExecutor({"test.py"})
+
+        assert executor.save_execution_log("..") is False
 
 
 class TestProgressDisplay:

--- a/tests/smart_scan/test_mapping.py
+++ b/tests/smart_scan/test_mapping.py
@@ -315,7 +315,6 @@ class TestDiscoveryCatalogResolves:
         "Amazon Timestream",
         "Amazon EMR",
         "Amazon Kinesis",
-        "Amazon CloudWatch Logs",
         "AWS Amplify",
     }
 

--- a/tests/smart_scan/test_selector.py
+++ b/tests/smart_scan/test_selector.py
@@ -6,6 +6,7 @@ Tests import structure, class instantiation, and method availability.
 
 import os
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -91,3 +92,33 @@ class TestSmartScanSelectorStructure:
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+class TestPlainTextFallback:
+    """The no-questionary path must offer a real plain-text selection,
+    not silently degrade to 'run everything' (the pre-fix bug)."""
+
+    SORTED = sorted(MOCK_RECOMMENDATIONS["all_scripts"])
+
+    def test_fallback_returns_selected_subset(self):
+        import utils
+        from smart_scan import selector
+        # sorted(all_scripts): rows 1..N. Pick rows 1 and 3.
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False), \
+             patch.object(utils, "prompt_multiselect", return_value=[1, 3]):
+            result = selector.interactive_select(MOCK_RECOMMENDATIONS)
+        assert result == {self.SORTED[0], self.SORTED[2]}
+
+    def test_fallback_back_returns_none(self):
+        import utils
+        from smart_scan import selector
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False), \
+             patch.object(utils, "prompt_multiselect", side_effect=utils.BackSignal):
+            result = selector.interactive_select(MOCK_RECOMMENDATIONS)
+        assert result is None
+
+    def test_fallback_empty_recommendations_returns_none(self):
+        from smart_scan import selector
+        with patch.object(selector, "QUESTIONARY_AVAILABLE", False):
+            result = selector.interactive_select({"all_scripts": set()})
+        assert result is None

--- a/tests/smart_scan/test_selector.py
+++ b/tests/smart_scan/test_selector.py
@@ -122,3 +122,66 @@ class TestPlainTextFallback:
         with patch.object(selector, "QUESTIONARY_AVAILABLE", False):
             result = selector.interactive_select({"all_scripts": set()})
         assert result is None
+
+
+@pytest.fixture
+def make_selector():
+    """Build a SmartScanSelector without requiring questionary to be installed.
+
+    The constructor guards on QUESTIONARY_AVAILABLE, but save_checklist() is a
+    plain file writer that never touches questionary.
+    """
+    from smart_scan import selector as selector_module
+
+    def _make(recommendations=MOCK_RECOMMENDATIONS):
+        with patch.object(selector_module, "QUESTIONARY_AVAILABLE", True):
+            return SmartScanSelector(recommendations)
+
+    return _make
+
+
+class TestSaveChecklistContainment:
+    """save_checklist() writes into output/ — previously it wrote to a bare
+    relative path, dropping the checklist in the caller's CWD (CWE-73)."""
+
+    def test_checklist_written_to_output_dir(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("checklist.txt") is True
+        assert (tmp_path / "checklist.txt").exists()
+
+    def test_checklist_not_written_to_cwd(self, tmp_path, monkeypatch, make_selector):
+        """Regression: the file must not land in the current working directory."""
+        import utils
+
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        monkeypatch.chdir(cwd)
+        monkeypatch.setattr(utils, "get_output_dir", lambda: out)
+        selector = make_selector()
+
+        assert selector.save_checklist("checklist.txt") is True
+        assert (out / "checklist.txt").exists()
+        assert not (cwd / "checklist.txt").exists()
+
+    def test_traversing_name_stays_contained(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("../../escaped.txt") is True
+        assert (tmp_path / "escaped.txt").exists()
+
+    def test_unusable_name_returns_false(self, tmp_path, monkeypatch, make_selector):
+        import utils
+
+        monkeypatch.setattr(utils, "get_output_dir", lambda: tmp_path)
+        selector = make_selector()
+
+        assert selector.save_checklist("..") is False

--- a/tests/test_exporters/test_resource_bundle.py
+++ b/tests/test_exporters/test_resource_bundle.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+Tests for scripts/_resource_bundle.py — the shared all-in-one bundle driver.
+
+Focus: prompt_script_selection() now delegates to utils.prompt_multiselect
+(single-voice), maps chosen indices back to (display, filename) tuples, and
+propagates the navigation signals (BackSignal / ExitToMainSignal / QuitSignal)
+instead of returning 'back'/'exit' sentinel strings.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+import _resource_bundle as bundle  # noqa: E402
+
+import utils  # noqa: E402
+
+SCRIPTS = [
+    ("Billing Export", "billing_export.py"),
+    ("Budgets Export", "budgets_export.py"),
+    ("Savings Plans Export", "savings_plans_export.py"),
+]
+
+
+class TestPromptScriptSelection:
+    def test_maps_indices_to_tuples(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', return_value=[1, 3]):
+            result = bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        assert result == [SCRIPTS[0], SCRIPTS[2]]
+
+    def test_auto_run_returns_all(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
+        result = bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        assert result == SCRIPTS
+
+    def test_back_signal_propagates(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', side_effect=utils.BackSignal), \
+             pytest.raises(utils.BackSignal):
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+
+    def test_exit_to_main_signal_propagates(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', side_effect=utils.ExitToMainSignal), \
+             pytest.raises(utils.ExitToMainSignal):
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+
+    def test_all_label_passed_through(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_multiselect', return_value=[1]) as mock_ms:
+            bundle.prompt_script_selection("Cost Management", SCRIPTS)
+        # An explicit All row replaces the old magic 0 = All convention.
+        _, kwargs = mock_ms.call_args
+        assert "all_label" in kwargs and kwargs["all_label"]

--- a/tests/test_org_scan.py
+++ b/tests/test_org_scan.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Tests for organization-wide scanning (--org-scan):
+- utils.list_organization_accounts (active filter)
+- utils.verify_assume_role (assume-role preflight)
+- utils.build_org_summary_dataframe (roll-up)
+- stratusscan._run_org_audit (per-account reports + summary, role-failed skip)
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+import stratusscan  # noqa: E402
+import utils  # noqa: E402
+
+pd = pytest.importorskip("pandas")
+
+
+# --- list_organization_accounts ------------------------------------------------
+
+class _FakePaginator:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def paginate(self, **kwargs):
+        return iter(self._pages)
+
+
+class _FakeOrgClient:
+    def __init__(self, pages):
+        self._pages = pages
+
+    def get_paginator(self, name):
+        assert name == "list_accounts"
+        return _FakePaginator(self._pages)
+
+
+class TestListOrganizationAccounts:
+    PAGES = [{
+        "Accounts": [
+            {"Id": "111111111111", "Name": "Audit", "Email": "a@x", "Status": "ACTIVE"},
+            {"Id": "222222222222", "Name": "Prod", "Email": "p@x", "Status": "ACTIVE"},
+            {"Id": "333333333333", "Name": "Old", "Email": "o@x", "Status": "SUSPENDED"},
+        ]
+    }]
+
+    def test_active_only_filters_suspended(self, monkeypatch):
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _FakeOrgClient(self.PAGES))
+        accounts = utils.list_organization_accounts(active_only=True)
+        ids = [a["id"] for a in accounts]
+        assert ids == ["111111111111", "222222222222"]
+        assert accounts[0]["name"] == "Audit"
+
+    def test_include_inactive(self, monkeypatch):
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _FakeOrgClient(self.PAGES))
+        assert len(utils.list_organization_accounts(active_only=False)) == 3
+
+
+# --- verify_assume_role --------------------------------------------------------
+
+class TestVerifyAssumeRole:
+    def test_success(self, monkeypatch):
+        class _STS:
+            def get_caller_identity(self):
+                return {"Account": "222222222222"}
+        monkeypatch.setattr(utils, "get_boto3_client", lambda *a, **k: _STS())
+        ok, err = utils.verify_assume_role("arn:aws:iam::222222222222:role/Scan")
+        assert ok is True and err is None
+
+    def test_failure_returns_error(self, monkeypatch):
+        def _boom(*a, **k):
+            raise Exception("AccessDenied: not authorized to assume role")
+        monkeypatch.setattr(utils, "get_boto3_client", _boom)
+        ok, err = utils.verify_assume_role("arn:aws:iam::333333333333:role/Scan")
+        assert ok is False
+        assert "AccessDenied" in err
+
+
+# --- build_org_summary_dataframe ----------------------------------------------
+
+class TestOrgSummary:
+    def test_rollup_rows_and_columns(self):
+        summaries = [
+            {"account_id": "222", "account_name": "Prod", "status": utils.ACCOUNT_STATUS_SCANNED,
+             "exporters": 2, "ok": 1, "empty": 1, "no_output": 0, "failed": 0,
+             "total_assets": 7, "report": "s3://b/prod.xlsx", "detail": ""},
+            {"account_id": "333", "account_name": "Dev", "status": utils.ACCOUNT_STATUS_ROLE_FAILED,
+             "exporters": 0, "ok": 0, "empty": 0, "no_output": 0, "failed": 0,
+             "total_assets": 0, "report": "", "detail": "AccessDenied"},
+        ]
+        df = utils.build_org_summary_dataframe(summaries)
+        assert list(df["Account"]) == ["Dev", "Prod"]  # sorted
+        prod = {r["Account"]: r for r in df.to_dict("records")}["Prod"]
+        assert prod["Status"] == utils.ACCOUNT_STATUS_SCANNED
+        assert prod["Total Assets"] == 7
+        assert prod["Report"] == "s3://b/prod.xlsx"
+        for col in ("Account ID", "Status", "With Data", "Failed", "Total Assets", "Report"):
+            assert col in df.columns
+
+    def test_empty_inputs(self):
+        df = utils.build_org_summary_dataframe([])
+        assert df.empty and "Status" in df.columns
+
+
+# --- _run_org_audit integration ------------------------------------------------
+
+WRITTEN_EXPORTER = '''\
+import os, json
+mp = os.environ["STRATUSSCAN_RUN_MANIFEST"]
+name = os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "")
+with open(mp, "a", encoding="utf-8") as f:
+    f.write(json.dumps({"exporter": name, "resource": name, "rows": 7,
+                        "status": "written", "file": "x.xlsx", "sheets": None,
+                        "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID")}) + "\\n")
+'''
+
+
+@pytest.fixture
+def org_env(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "alpha_export.py").write_text(WRITTEN_EXPORTER)
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+
+    monkeypatch.setattr(utils, "validate_aws_credentials", lambda: (True, "111111111111", "AUDIT"))
+    monkeypatch.setattr(utils, "detect_partition", lambda *a, **k: "aws")
+    monkeypatch.setattr(utils, "get_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(utils, "get_output_dir", lambda: out_dir)
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-org"))
+
+    monkeypatch.setattr(utils, "list_organization_accounts", lambda active_only=True: [
+        {"id": "222222222222", "name": "Prod", "email": "", "status": "ACTIVE"},
+        {"id": "333333333333", "name": "Dev", "email": "", "status": "ACTIVE"},
+    ])
+
+    # Prod assumable, Dev not (StackSet not yet rolled out there).
+    def fake_verify(role_arn, region_name=None):
+        return ("222222222222" in role_arn, None if "222222222222" in role_arn else "AccessDenied")
+    monkeypatch.setattr(utils, "verify_assume_role", fake_verify)
+
+    def fake_config_value(key, default=None, section=None):
+        return {"format": "xlsx", "skip_empty_exports": True,
+                "destination": "local", "s3": {"bucket": "", "prefix": "stratusscan/"}}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+    monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+
+    return out_dir
+
+
+class TestRunOrgAudit:
+    def test_per_account_reports_and_summary(self, org_env):
+        out_dir = org_env
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", None)
+        assert exc.value.code == 0  # at least one account scanned
+
+        # Prod (assumable) got a per-account run report; Dev (role failed) did not.
+        prod_reports = list(out_dir.glob("Prod-222222222222-audit-run-report*.xlsx"))
+        dev_reports = list(out_dir.glob("Dev-333333333333-audit-run-report*.xlsx"))
+        assert len(prod_reports) == 1
+        assert dev_reports == []
+
+        summaries = list(out_dir.glob("*org-audit-summary*.xlsx"))
+        assert len(summaries) == 1
+        df = pd.read_excel(summaries[0])
+        rows = {r["Account"]: r for r in df.to_dict("records")}
+        assert rows["Prod"]["Status"] == utils.ACCOUNT_STATUS_SCANNED
+        assert rows["Prod"]["Total Assets"] == 7
+        assert rows["Dev"]["Status"] == utils.ACCOUNT_STATUS_ROLE_FAILED
+
+    def test_all_role_failed_exits_one(self, org_env, monkeypatch):
+        monkeypatch.setattr(utils, "verify_assume_role", lambda role_arn, region_name=None: (False, "AccessDenied"))
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", None)
+        assert exc.value.code == 1
+
+    def test_exclude_accounts(self, org_env):
+        out_dir = org_env
+        with pytest.raises(SystemExit):
+            stratusscan._run_org_audit("us-east-1", "local", "ScanRole", "222222222222")
+        # Prod excluded → only Dev considered (role-failed) → no Prod report
+        assert list(out_dir.glob("Prod-*audit-run-report*.xlsx")) == []

--- a/tests/test_run_all_orchestrator.py
+++ b/tests/test_run_all_orchestrator.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the headless --run-all orchestrator (_run_full_audit in
+stratusscan.py).
+
+Uses tiny fake *_export.py subprocesses (stdlib only) that append a manifest
+record, so the test drives the real subprocess loop, manifest read, report
+build, report save, and exit-code logic without touching AWS.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+
+import stratusscan  # noqa: E402
+import utils  # noqa: E402
+
+pd = pytest.importorskip("pandas")
+
+
+WRITTEN_EXPORTER = '''\
+import os, json
+mp = os.environ["STRATUSSCAN_RUN_MANIFEST"]
+name = os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "")
+with open(mp, "a", encoding="utf-8") as f:
+    f.write(json.dumps({
+        "exporter": name, "resource": name, "rows": 7, "status": "written",
+        "file": "out/%s.xlsx" % name, "sheets": None,
+        "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID"),
+        "regions": os.environ.get("STRATUSSCAN_REGIONS"),
+    }) + "\\n")
+'''
+
+FAILING_EXPORTER = "import sys; sys.exit(1)\n"
+
+
+@pytest.fixture
+def audit_env(tmp_path, monkeypatch):
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    out_dir = tmp_path / "output"
+    out_dir.mkdir()
+
+    monkeypatch.setattr(utils, "validate_aws_credentials", lambda: (True, "123456789012", "TESTACCT"))
+    monkeypatch.setattr(utils, "get_scripts_dir", lambda: scripts_dir)
+    monkeypatch.setattr(utils, "get_output_dir", lambda: out_dir)
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-orchestrator"))
+
+    def fake_config_value(key, default=None, section=None):
+        return {"format": "xlsx", "skip_empty_exports": True,
+                "destination": "local", "s3": {"bucket": "", "prefix": "stratusscan/"}}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+    monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+
+    return scripts_dir, out_dir
+
+
+def _write(scripts_dir, name, body):
+    (scripts_dir / name).write_text(body)
+
+
+class TestRunFullAudit:
+    def test_happy_path_builds_report_and_exits_zero(self, audit_env):
+        scripts_dir, out_dir = audit_env
+        _write(scripts_dir, "alpha_export.py", WRITTEN_EXPORTER)
+        _write(scripts_dir, "zeta_export.py", FAILING_EXPORTER)
+
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit("us-east-1,us-west-2", "local")
+        assert exc.value.code == 0  # at least one exporter succeeded
+
+        reports = list(out_dir.glob("*audit-run-report*.xlsx"))
+        assert len(reports) == 1
+
+        df = pd.read_excel(reports[0])
+        rows = {r["Exporter"]: r for r in df.to_dict("records")}
+        assert rows["alpha_export.py"]["Status"] == utils.RUN_STATUS_OK
+        assert rows["alpha_export.py"]["Assets"] == 7
+        assert rows["zeta_export.py"]["Status"] == utils.RUN_STATUS_FAILED
+
+        # The per-run manifest was written next to the report
+        assert list(out_dir.glob("*audit-run-manifest*.jsonl"))
+
+    def test_all_failed_exits_one(self, audit_env):
+        scripts_dir, out_dir = audit_env
+        _write(scripts_dir, "alpha_export.py", FAILING_EXPORTER)
+
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "local")
+        assert exc.value.code == 1
+
+    def test_no_exporters_exits_one(self, audit_env):
+        # empty scripts dir
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "local")
+        assert exc.value.code == 1
+
+    def test_output_s3_without_bucket_exits_two(self, audit_env):
+        scripts_dir, _ = audit_env
+        _write(scripts_dir, "alpha_export.py", WRITTEN_EXPORTER)
+        with pytest.raises(SystemExit) as exc:
+            stratusscan._run_full_audit(None, "s3")
+        assert exc.value.code == 2

--- a/tests/test_run_manifest.py
+++ b/tests/test_run_manifest.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Tests for empty-export suppression and the per-run manifest in utils.py
+(headless --run-all safety layer).
+
+Covers:
+- skip_empty_exports: empty data writes no file; returns the truthy sentinel
+- non-empty exports still write and return a real path
+- skip_empty=False writes empty files (opt-out)
+- multi-sheet: all-empty suppressed, partial written
+- run manifest (STRATUSSCAN_RUN_MANIFEST) records written/empty rows + context
+- manifest absent when the env var is unset
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+pd = pytest.importorskip("pandas")
+
+
+@pytest.fixture
+def out_dir(tmp_path, monkeypatch):
+    """Isolate exports to a tmp dir and make delivery a no-op passthrough."""
+    d = tmp_path / "output"
+    d.mkdir()
+    # save_* use the module-global `logger`, which is None until setup_logging();
+    # inject one so the save path doesn't AttributeError in the test process.
+    monkeypatch.setattr(utils, "logger", logging.getLogger("test-run-manifest"))
+    monkeypatch.setattr(utils, "get_output_dir", lambda: d)
+    # deliver_output is exercised by the S3 tests; here we want the local path back.
+    monkeypatch.setattr(utils, "deliver_output", lambda p: p)
+    return d
+
+
+def _config(monkeypatch, *, fmt="xlsx", skip_empty=True):
+    def fake_config_value(key, default=None, section=None):
+        return {"format": fmt, "skip_empty_exports": skip_empty}.get(key, default)
+    monkeypatch.setattr(utils, "config_value", fake_config_value)
+
+
+def _files(d):
+    return sorted(p.name for p in d.iterdir())
+
+
+class TestSkipEmptySingle:
+    def test_empty_df_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert result  # truthy → exporters' `if output_path:` success path holds
+        assert _files(out_dir) == []
+
+    def test_nonempty_df_written(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        df = pd.DataFrame({"InstanceId": ["i-1", "i-2"]})
+        result = utils.save_dataframe_to_excel(df, "acct-ec2-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-ec2-export-01.01.2026.xlsx"]
+
+    def test_skip_empty_disabled_writes_empty(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=False)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-ec2-export-01.01.2026.xlsx"]
+
+    def test_empty_csv_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, fmt="csv", skip_empty=True)
+        result = utils.save_dataframe_to_excel(pd.DataFrame(), "acct-ec2-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == []
+
+
+class TestSkipEmptyMulti:
+    def test_all_sheets_empty_suppressed(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        sheets = {"VPCs": pd.DataFrame(), "Subnets": pd.DataFrame()}
+        result = utils.save_multiple_dataframes_to_excel(sheets, "acct-vpc-export-01.01.2026.xlsx")
+        assert result == utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == []
+
+    def test_partial_data_written(self, out_dir, monkeypatch):
+        _config(monkeypatch, skip_empty=True)
+        sheets = {"VPCs": pd.DataFrame({"VpcId": ["vpc-1"]}), "Subnets": pd.DataFrame()}
+        result = utils.save_multiple_dataframes_to_excel(sheets, "acct-vpc-export-01.01.2026.xlsx")
+        assert result != utils.EMPTY_EXPORT_SENTINEL
+        assert _files(out_dir) == ["acct-vpc-export-01.01.2026.xlsx"]
+
+
+class TestRunManifest:
+    def test_records_written_export(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+        monkeypatch.setenv("STRATUSSCAN_CURRENT_EXPORTER", "ec2_export.py")
+        monkeypatch.setenv("STRATUSSCAN_ACCOUNT_ID", "123456789012")
+        monkeypatch.setenv("STRATUSSCAN_ACCOUNT_NAME", "PROD")
+        monkeypatch.setenv("STRATUSSCAN_REGIONS", "us-east-1,us-west-2")
+
+        df = pd.DataFrame({"InstanceId": ["i-1", "i-2", "i-3"]})
+        utils.save_dataframe_to_excel(df, "PROD-ec2-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        r = records[0]
+        assert r["exporter"] == "ec2_export.py"
+        assert r["account_id"] == "123456789012"
+        assert r["account_name"] == "PROD"
+        assert r["regions"] == "us-east-1,us-west-2"
+        assert r["rows"] == 3
+        assert r["status"] == "written"
+        assert r["file"] is not None
+
+    def test_records_empty_export(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+        monkeypatch.setenv("STRATUSSCAN_CURRENT_EXPORTER", "ec2_export.py")
+
+        utils.save_dataframe_to_excel(pd.DataFrame(), "PROD-ec2-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        assert records[0]["status"] == "empty"
+        assert records[0]["rows"] == 0
+        assert records[0]["file"] is None
+
+    def test_multi_sheet_records_per_sheet_counts(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        manifest = tmp_path / "manifest.jsonl"
+        monkeypatch.setenv("STRATUSSCAN_RUN_MANIFEST", str(manifest))
+
+        sheets = {"VPCs": pd.DataFrame({"VpcId": ["vpc-1", "vpc-2"]}), "Subnets": pd.DataFrame({"SubnetId": ["s-1"]})}
+        utils.save_multiple_dataframes_to_excel(sheets, "PROD-vpc-export-01.01.2026.xlsx")
+
+        records = utils.read_run_manifest(str(manifest))
+        assert len(records) == 1
+        assert records[0]["rows"] == 3
+        assert records[0]["sheets"] == {"VPCs": 2, "Subnets": 1}
+
+    def test_no_manifest_when_env_unset(self, out_dir, monkeypatch, tmp_path):
+        _config(monkeypatch, skip_empty=True)
+        monkeypatch.delenv("STRATUSSCAN_RUN_MANIFEST", raising=False)
+        manifest = tmp_path / "manifest.jsonl"
+
+        utils.save_dataframe_to_excel(pd.DataFrame({"x": [1]}), "PROD-ec2-export-01.01.2026.xlsx")
+        assert not manifest.exists()
+
+    def test_read_missing_manifest_returns_empty(self, tmp_path):
+        assert utils.read_run_manifest(str(tmp_path / "nope.jsonl")) == []

--- a/tests/test_run_report.py
+++ b/tests/test_run_report.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Tests for the run-report builder (utils.build_run_report_dataframe) and the
+STRATUSSCAN_OUTPUT_DESTINATION override in resolve_s3_destination.
+
+The report merges per-script execution results with per-save manifest records
+into the four auditor-facing outcomes: OK, EMPTY, NO OUTPUT, FAILED.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+pytest.importorskip("pandas")
+
+
+def _rows_by_exporter(df):
+    return {r["Exporter"]: r for r in df.to_dict("records")}
+
+
+class TestBuildRunReport:
+    def _build(self):
+        executor_results = [
+            {"script": "ec2_export.py", "success": True, "return_code": 0, "duration_seconds": 3.2, "error_message": None},
+            {"script": "vpc_export.py", "success": True, "return_code": 0, "duration_seconds": 1.0, "error_message": None},
+            {"script": "rds_export.py", "success": True, "return_code": 0, "duration_seconds": 2.0, "error_message": None},
+            {"script": "iam_export.py", "success": False, "return_code": 1, "duration_seconds": 0.5, "error_message": "boom"},
+        ]
+        manifest_records = [
+            {"exporter": "ec2_export.py", "rows": 5, "status": "written", "file": "s3://b/ec2.xlsx", "sheets": None, "regions": "us-east-1"},
+            {"exporter": "vpc_export.py", "rows": 0, "status": "empty", "file": None, "sheets": {"VPCs": 0, "Subnets": 0}, "regions": "us-east-1"},
+            # rds_export.py: ran clean but never saved → NO OUTPUT
+            # iam_export.py: failed before/while saving → FAILED
+        ]
+        return utils.build_run_report_dataframe(executor_results, manifest_records)
+
+    def test_status_classification(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Status"] == utils.RUN_STATUS_OK
+        assert rows["vpc_export.py"]["Status"] == utils.RUN_STATUS_EMPTY
+        assert rows["rds_export.py"]["Status"] == utils.RUN_STATUS_NO_OUTPUT
+        assert rows["iam_export.py"]["Status"] == utils.RUN_STATUS_FAILED
+
+    def test_asset_counts(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Assets"] == 5
+        assert rows["vpc_export.py"]["Assets"] == 0
+        assert rows["rds_export.py"]["Assets"] == 0
+
+    def test_output_file_only_for_written(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["ec2_export.py"]["Output File"] == "s3://b/ec2.xlsx"
+        assert rows["vpc_export.py"]["Output File"] == ""
+        assert rows["rds_export.py"]["Output File"] == ""
+
+    def test_failed_detail_carries_error(self):
+        rows = _rows_by_exporter(self._build())
+        assert "boom" in rows["iam_export.py"]["Detail"]
+
+    def test_sheets_rendered(self):
+        rows = _rows_by_exporter(self._build())
+        assert rows["vpc_export.py"]["Sheets"] == "VPCs:0, Subnets:0"
+
+    def test_sorted_by_exporter(self):
+        df = self._build()
+        assert list(df["Exporter"]) == sorted(df["Exporter"])
+
+    def test_empty_inputs_yield_empty_frame_with_columns(self):
+        df = utils.build_run_report_dataframe([], [])
+        assert df.empty
+        assert "Status" in df.columns and "Assets" in df.columns
+
+
+class TestOutputDestinationOverride:
+    def _config(self, monkeypatch, destination, bucket):
+        def fake(key, default=None, section=None):
+            return {
+                "destination": destination,
+                "s3": {"bucket": bucket, "prefix": "stratusscan/"},
+            }.get(key, default)
+        monkeypatch.setattr(utils, "config_value", fake)
+        for var in ("STRATUSSCAN_OUTPUT_DESTINATION", "STRATUSSCAN_S3_BUCKET", "STRATUSSCAN_S3_PREFIX"):
+            monkeypatch.delenv(var, raising=False)
+
+    def test_env_forces_s3(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="cfg-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "s3")
+        assert utils.resolve_s3_destination()["enabled"] is True
+
+    def test_env_forces_local_over_config_s3(self, monkeypatch):
+        self._config(monkeypatch, destination="s3", bucket="cfg-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_env_forces_local_over_bucket_env(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="")
+        monkeypatch.setenv("STRATUSSCAN_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "local")
+        # explicit local wins even though a bucket env is set
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_s3_force_without_bucket_not_enabled(self, monkeypatch):
+        self._config(monkeypatch, destination="local", bucket="")
+        monkeypatch.setenv("STRATUSSCAN_OUTPUT_DESTINATION", "s3")
+        assert utils.resolve_s3_destination()["enabled"] is False

--- a/tests/test_s3_upload.py
+++ b/tests/test_s3_upload.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Moto-based tests for the S3 output-delivery feature (Issue #175) in utils.py.
+
+Covers:
+- upload_to_s3()            — success deletes local + returns s3 uri; failure retains local
+- deliver_output()          — routes to S3 when enabled, passthrough when local
+- resolve_s3_destination()  — config vs STRATUSSCAN_S3_BUCKET env override
+- test_s3_connectivity()    — HeadBucket -> PutObject -> DeleteObject step reporting
+- _build_s3_key()           — prefix/basename joining
+"""
+
+import sys
+from pathlib import Path
+
+import boto3
+import pytest
+from moto import mock_aws
+
+try:
+    import utils
+except ImportError:
+    sys.path.insert(0, str(Path(__file__).parent.parent))
+    import utils
+
+REGION = "us-east-1"
+BUCKET = "stratusscan-test-bucket"
+
+
+@pytest.fixture(autouse=True)
+def fake_aws_credentials(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", REGION)
+    # Ensure no stray env override leaks between tests.
+    monkeypatch.delenv("STRATUSSCAN_S3_BUCKET", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_S3_PREFIX", raising=False)
+    monkeypatch.delenv("STRATUSSCAN_REGIONS", raising=False)
+
+
+def _make_bucket():
+    s3 = boto3.client("s3", region_name=REGION)
+    s3.create_bucket(Bucket=BUCKET)
+    return s3
+
+
+def _local_file(tmp_path, name="acct-ec2-export-01.01.2026.xlsx", body=b"data"):
+    p = tmp_path / name
+    p.write_bytes(body)
+    return str(p)
+
+
+class TestBuildS3Key:
+    def test_prefix_and_basename_joined(self):
+        assert utils._build_s3_key("stratusscan/", "/out/acct-ec2.xlsx") == "stratusscan/acct-ec2.xlsx"
+
+    def test_prefix_without_trailing_slash_gets_one(self):
+        assert utils._build_s3_key("evidence", "/out/x.csv") == "evidence/x.csv"
+
+    def test_empty_prefix_is_bare_key(self):
+        assert utils._build_s3_key("", "/out/x.csv") == "x.csv"
+
+    def test_leading_slash_stripped(self):
+        assert utils._build_s3_key("/stratusscan/", "/out/x.csv") == "stratusscan/x.csv"
+
+
+class TestUploadToS3:
+    @mock_aws
+    def test_success_uploads_and_deletes_local(self, tmp_path):
+        s3 = _make_bucket()
+        local = _local_file(tmp_path)
+
+        uri = utils.upload_to_s3(local, BUCKET, "stratusscan/")
+
+        assert uri == f"s3://{BUCKET}/stratusscan/acct-ec2-export-01.01.2026.xlsx"
+        # Object landed in S3
+        obj = s3.get_object(Bucket=BUCKET, Key="stratusscan/acct-ec2-export-01.01.2026.xlsx")
+        assert obj["Body"].read() == b"data"
+        # Local copy deleted on success
+        assert not Path(local).exists()
+
+    @mock_aws
+    def test_failure_retains_local_and_returns_none(self, tmp_path):
+        _make_bucket()
+        local = _local_file(tmp_path)
+
+        # Upload to a bucket that does not exist -> failure
+        uri = utils.upload_to_s3(local, "no-such-bucket-xyz", "stratusscan/")
+
+        assert uri is None
+        assert Path(local).exists()  # retained as fallback
+
+    @mock_aws
+    def test_missing_local_file_returns_none(self):
+        _make_bucket()
+        assert utils.upload_to_s3("/does/not/exist.xlsx", BUCKET) is None
+
+    def test_empty_bucket_returns_none(self, tmp_path):
+        local = _local_file(tmp_path)
+        assert utils.upload_to_s3(local, "") is None
+        assert Path(local).exists()
+
+
+class TestResolveS3Destination:
+    def test_env_var_forces_s3(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("STRATUSSCAN_S3_PREFIX", "ci/")
+        dest = utils.resolve_s3_destination()
+        assert dest == {"enabled": True, "bucket": "env-bucket", "prefix": "ci/"}
+
+    def test_config_s3_destination(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "s3",
+                ("s3", "output_settings"): {"bucket": "cfg-bucket", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        dest = utils.resolve_s3_destination()
+        assert dest["enabled"] is True
+        assert dest["bucket"] == "cfg-bucket"
+        assert dest["prefix"] == "stratusscan/"
+
+    def test_local_destination_not_enabled(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "local",
+                ("s3", "output_settings"): {"bucket": "", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+    def test_s3_selected_but_no_bucket_not_enabled(self, monkeypatch):
+        def fake_config_value(key, default=None, section=None):
+            values = {
+                ("destination", "output_settings"): "s3",
+                ("s3", "output_settings"): {"bucket": "", "prefix": "stratusscan/"},
+            }
+            return values.get((key, section), default)
+
+        monkeypatch.setattr(utils, "config_value", fake_config_value)
+        assert utils.resolve_s3_destination()["enabled"] is False
+
+
+class TestDeliverOutput:
+    def test_local_destination_passthrough(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": False, "bucket": "", "prefix": ""},
+        )
+        local = _local_file(tmp_path)
+        assert utils.deliver_output(local) == local
+        assert Path(local).exists()
+
+    @mock_aws
+    def test_s3_destination_uploads(self, monkeypatch, tmp_path):
+        _make_bucket()
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": True, "bucket": BUCKET, "prefix": "stratusscan/"},
+        )
+        local = _local_file(tmp_path)
+        result = utils.deliver_output(local)
+        assert result.startswith(f"s3://{BUCKET}/stratusscan/")
+        assert not Path(local).exists()
+
+    @mock_aws
+    def test_failed_upload_falls_back_to_local(self, monkeypatch, tmp_path):
+        # bucket not created -> upload fails -> deliver returns local path
+        monkeypatch.setattr(
+            utils, "resolve_s3_destination",
+            lambda: {"enabled": True, "bucket": "missing-bucket", "prefix": "stratusscan/"},
+        )
+        local = _local_file(tmp_path)
+        assert utils.deliver_output(local) == local
+        assert Path(local).exists()
+
+
+class TestS3Connectivity:
+    @mock_aws
+    def test_full_roundtrip_ok(self):
+        _make_bucket()
+        result = utils.test_s3_connectivity(BUCKET, "stratusscan/")
+        assert result["ok"] is True
+        assert result["failed_step"] is None
+        assert [s["step"] for s in result["steps"]] == ["HeadBucket", "PutObject", "DeleteObject"]
+        assert all(s["ok"] for s in result["steps"])
+        # Probe object cleaned up
+        s3 = boto3.client("s3", region_name=REGION)
+        assert "Contents" not in s3.list_objects_v2(Bucket=BUCKET)
+
+    @mock_aws
+    def test_missing_bucket_fails_at_headbucket(self):
+        result = utils.test_s3_connectivity("no-such-bucket-zzz", "stratusscan/")
+        assert result["ok"] is False
+        assert result["failed_step"] == "HeadBucket"
+
+    def test_no_bucket_fails_at_config(self):
+        result = utils.test_s3_connectivity("", "stratusscan/")
+        assert result["ok"] is False
+        assert result["failed_step"] == "config"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -336,8 +336,13 @@ class TestPromptMenu:
         with patch('builtins.input', return_value='b'), pytest.raises(utils.BackSignal):
             utils.prompt_menu("TEST MENU", ["Option A"])
 
-    def test_exit_raises_signal(self):
-        with patch('builtins.input', return_value='x'), pytest.raises(utils.QuitSignal):
+    def test_exit_raises_exit_to_main_signal(self):
+        # 'x' = main menu — the single-voice standard (was QuitSignal before).
+        with patch('builtins.input', return_value='x'), pytest.raises(utils.ExitToMainSignal):
+            utils.prompt_menu("TEST MENU", ["Option A"])
+
+    def test_quit_raises_quit_signal(self):
+        with patch('builtins.input', return_value='q'), pytest.raises(utils.QuitSignal):
             utils.prompt_menu("TEST MENU", ["Option A"])
 
     def test_invalid_then_valid(self):
@@ -349,6 +354,22 @@ class TestPromptMenu:
         monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
         result = utils.prompt_menu("TEST MENU", ["Option A", "Option B"])
         assert result == 1
+
+
+class TestNavFooter:
+    """Locks the single-voice navigation footer + interaction constants."""
+
+    def test_full_footer_wording(self):
+        assert utils._nav_footer() == "  b = back  |  x = main menu  |  q = quit"
+
+    def test_footer_includes_only_enabled_keys(self):
+        assert utils._nav_footer(allow_back=False) == "  x = main menu  |  q = quit"
+        assert utils._nav_footer(allow_exit=False, allow_quit=False) == "  b = back"
+
+    def test_constants(self):
+        assert utils.GLYPH_OK == "✅"
+        assert utils.GLYPH_FAIL == "❌"
+        assert utils.MSG_INVALID_SELECTION == "Invalid selection. Please try again."
 
 
 class TestPromptRegionSelectionNew:
@@ -384,6 +405,15 @@ class TestPromptRegionSelectionNew:
     def test_exit_returns_string(self, monkeypatch):
         monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
         with patch('utils.prompt_menu', side_effect=utils.QuitSignal), \
+             patch('utils.get_default_regions', return_value=['us-east-1']), \
+             patch('utils.detect_partition', return_value='aws'):
+            result = utils.prompt_region_selection()
+        assert result == 'exit'
+
+    def test_exit_to_main_returns_string(self, monkeypatch):
+        # 'x' from the region menu surfaces as ExitToMainSignal → 'exit'.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('utils.prompt_menu', side_effect=utils.ExitToMainSignal), \
              patch('utils.get_default_regions', return_value=['us-east-1']), \
              patch('utils.detect_partition', return_value='aws'):
             result = utils.prompt_region_selection()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -372,6 +372,63 @@ class TestNavFooter:
         assert utils.MSG_INVALID_SELECTION == "Invalid selection. Please try again."
 
 
+class TestPromptMultiselect:
+    """Tests for prompt_multiselect() — the shared numbered multi-select."""
+
+    OPTS = ["Alpha", "Bravo", "Charlie"]
+
+    def test_single_pick(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='2'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [2]
+
+    def test_multi_pick(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='1 3'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [1, 3]
+
+    def test_dedupe_preserves_order(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='3 1 3'):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [3, 1]
+
+    def test_all_row_selects_everything(self, monkeypatch):
+        # With an All row, row 1 = All → returns every option index.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='1'):
+            assert utils.prompt_multiselect("PICK", self.OPTS, all_label="All") == [1, 2, 3]
+
+    def test_all_row_offsets_option_indices(self, monkeypatch):
+        # Row 2 (with All at row 1) maps back to option index 1.
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='2 4'):
+            assert utils.prompt_multiselect("PICK", self.OPTS, all_label="All") == [1, 3]
+
+    def test_back_raises_signal(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='b'), pytest.raises(utils.BackSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_exit_raises_exit_to_main(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='x'), pytest.raises(utils.ExitToMainSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_quit_raises_quit(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', return_value='q'), pytest.raises(utils.QuitSignal):
+            utils.prompt_multiselect("PICK", self.OPTS)
+
+    def test_invalid_then_valid(self, monkeypatch):
+        monkeypatch.delenv("STRATUSSCAN_AUTO_RUN", raising=False)
+        with patch('builtins.input', side_effect=['z', '9', '2']):
+            assert utils.prompt_multiselect("PICK", self.OPTS) == [2]
+
+    def test_auto_run_returns_all(self, monkeypatch):
+        monkeypatch.setenv("STRATUSSCAN_AUTO_RUN", "1")
+        assert utils.prompt_multiselect("PICK", self.OPTS) == [1, 2, 3]
+
+
 class TestPromptRegionSelectionNew:
     """Tests for the rewritten prompt_region_selection() function."""
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -645,3 +645,134 @@ class TestParseScriptArgs:
     def teardown_method(self, method):
         """Reset _SCRIPT_ARGS after each test to avoid cross-test contamination."""
         utils._SCRIPT_ARGS = None
+
+
+class TestSanitizeFilenameComponent:
+    """sanitize_filename_component() strips path-altering characters (CWE-73)
+    without disturbing ordinary names."""
+
+    @pytest.mark.parametrize("value", [
+        'PROD-ACCOUNT',
+        'ec2',
+        'my account 01',
+        'acct_name-v2',
+        'Account.Name',
+        '',
+    ])
+    def test_ordinary_names_pass_through_unchanged(self, value):
+        assert utils.sanitize_filename_component(value) == value
+
+    def test_forward_slash_stripped(self):
+        assert utils.sanitize_filename_component('a/b') == 'ab'
+
+    def test_backslash_stripped(self):
+        assert utils.sanitize_filename_component(r'a\b') == 'ab'
+
+    def test_parent_directory_marker_stripped(self):
+        assert utils.sanitize_filename_component('../etc') == 'etc'
+
+    def test_nested_parent_markers_cannot_reconstitute(self):
+        # A single non-repeating pass on '....' would leave '..'
+        assert '..' not in utils.sanitize_filename_component('....')
+
+    def test_null_byte_stripped(self):
+        assert utils.sanitize_filename_component('a\x00b') == 'ab'
+
+    def test_control_characters_stripped(self):
+        assert utils.sanitize_filename_component('a\r\nb') == 'ab'
+
+    def test_leading_and_trailing_dots_and_spaces_stripped(self):
+        assert utils.sanitize_filename_component('  .hidden.  ') == 'hidden'
+
+    def test_traversal_payload_is_defanged(self):
+        assert utils.sanitize_filename_component('../../etc/passwd') == 'etcpasswd'
+
+    def test_non_string_input_coerced(self):
+        assert utils.sanitize_filename_component(42) == '42'
+
+
+class TestContainedPath:
+    """contained_path() confines a caller-supplied name to a base directory."""
+
+    def test_plain_filename_resolves_inside_base(self, tmp_path):
+        result = utils.contained_path(tmp_path, 'report.xlsx')
+        assert result == tmp_path / 'report.xlsx'
+
+    def test_traversal_is_reduced_to_basename(self, tmp_path):
+        # basename() collapses the traversal rather than escaping
+        result = utils.contained_path(tmp_path, '../../etc/passwd')
+        assert result == tmp_path / 'passwd'
+        assert result.parent == tmp_path
+
+    def test_absolute_path_is_reduced_to_basename(self, tmp_path):
+        result = utils.contained_path(tmp_path, '/etc/shadow')
+        assert result == tmp_path / 'shadow'
+
+    @pytest.mark.parametrize("bad", ['', '.', '..', '/', '../'])
+    def test_names_with_no_usable_component_are_rejected(self, tmp_path, bad):
+        with pytest.raises(ValueError):
+            utils.contained_path(tmp_path, bad)
+
+    def test_result_never_escapes_base(self, tmp_path):
+        for candidate in ['a/b/c.txt', '../x.txt', './y.txt', 'z.txt']:
+            result = utils.contained_path(tmp_path, candidate)
+            assert result.resolve().parent == tmp_path.resolve()
+
+    def test_get_output_filepath_delegates_to_containment(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(utils, 'get_output_dir', lambda: tmp_path)
+        assert utils.get_output_filepath('../escape.xlsx') == tmp_path / 'escape.xlsx'
+
+
+class TestExportFilenameContainment:
+    """A crafted account_name in config.json must not steer the export path."""
+
+    def test_normal_account_name_is_untouched(self):
+        filename = utils.create_export_filename(
+            account_name='PROD-ACCOUNT', resource_type='ec2', suffix='running'
+        )
+        assert filename.startswith('PROD-ACCOUNT-ec2-running-export-')
+
+    def test_traversal_in_account_name_is_stripped(self):
+        filename = utils.create_export_filename(
+            account_name='../../etc', resource_type='ec2', suffix=''
+        )
+        assert '..' not in filename
+        assert '/' not in filename
+
+    def test_traversal_in_resource_type_is_stripped(self):
+        filename = utils.create_export_filename(
+            account_name='ACCT', resource_type='../ec2', suffix=''
+        )
+        assert '..' not in filename
+        assert '/' not in filename
+
+    def test_sanitized_filename_stays_contained(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(utils, 'get_output_dir', lambda: tmp_path)
+        filename = utils.create_export_filename(
+            account_name='../../../tmp/evil', resource_type='ec2', suffix=''
+        )
+        assert utils.get_output_filepath(filename).parent == tmp_path
+
+
+class TestLogErrorScrubbing:
+    """Every log_error() branch must scrub CRLF (CWE-117), including the
+    debug/stack-trace branch."""
+
+    def test_debug_branch_scrubs_crlf(self):
+        mock_logger = Mock()
+        with patch.object(utils, 'get_logger', return_value=mock_logger):
+            utils.log_error('boom', ValueError('line1\r\nFAKE: forged entry'))
+
+        debug_message = mock_logger.debug.call_args[0][0]
+        assert '\n' not in debug_message
+        assert '\r' not in debug_message
+        assert 'FAKE: forged entry' in debug_message
+
+    def test_error_branch_still_scrubs_crlf(self):
+        mock_logger = Mock()
+        with patch.object(utils, 'get_logger', return_value=mock_logger):
+            utils.log_error('boom', ValueError('a\r\nb'))
+
+        error_message = mock_logger.error.call_args[0][0]
+        assert '\n' not in error_message
+        assert '\r' not in error_message

--- a/utils.py
+++ b/utils.py
@@ -955,6 +955,12 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
         if prepare:
             df = prepare_dataframe_for_export(df)
 
+        # Empty-export suppression + manifest accounting (applies to both formats)
+        rows = int(len(df))
+        skipped = _maybe_skip_empty(filename, rows)
+        if skipped is not None:
+            return skipped
+
         if fmt == "csv":
             # Normalise filename: strip .xlsx if caller passed it, force .csv
             if filename.endswith(".xlsx"):
@@ -966,7 +972,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             df.to_csv(output_path, index=False)
             logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-            return deliver_output(str(output_path))
+            return _finalize_export(str(output_path), rows)
 
         # --- xlsx path ---
         # Ensure the output directory exists
@@ -988,7 +994,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             df.to_excel(output_path, sheet_name=sheet_name, index=False)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return deliver_output(str(output_path))
+        return _finalize_export(str(output_path), rows)
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1031,6 +1037,14 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                 for sheet_name, df in dataframes_dict.items()
             }
 
+        # Per-sheet counts drive empty-suppression (skip only when ALL sheets are
+        # empty) and the manifest's asset accounting.
+        sheets = {name: int(len(df)) for name, df in dataframes_dict.items()}
+        total_rows = sum(sheets.values())
+        skipped = _maybe_skip_empty(filename, total_rows, sheets)
+        if skipped is not None:
+            return skipped
+
         output_dir = get_output_dir()
         os.makedirs(output_dir, exist_ok=True)
 
@@ -1051,7 +1065,11 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                 logger.info(_scrub_log(f"Data successfully exported to: {csv_path}"))
                 delivered.append(deliver_output(str(csv_path)))
 
-            return delivered[0] if delivered else None
+            first = delivered[0] if delivered else None
+            # One manifest line for the whole multi-sheet export (first CSV as the
+            # representative file), with per-sheet counts preserved.
+            _record_run_manifest(filename, total_rows, "written", first, sheets)
+            return first
 
         # --- xlsx path ---
         output_path = get_output_filepath(filename)
@@ -1083,7 +1101,7 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     _adjust_column_widths(writer.sheets[sheet_name], df)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return deliver_output(str(output_path))
+        return _finalize_export(str(output_path), total_rows, sheets)
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1348,6 +1366,137 @@ def test_s3_connectivity(
 
     result["ok"] = True
     return result
+
+
+# ---------------------------------------------------------------------------
+# Empty-export suppression + per-run manifest (audit run report)
+# ---------------------------------------------------------------------------
+#
+# Two coupled behaviours that make an unattended --run-all audit trustworthy:
+#
+#   * skip-empty — when an exporter produces no rows, no spreadsheet is written.
+#     This removes the noise of dozens of 0-row workbooks and, crucially, kills
+#     the "empty file looks like a broken exporter" false positive.
+#
+#   * run manifest — every save records what ran and how many assets it found
+#     (including the empties). The manifest is the authoritative answer to
+#     "EC2 was expected but no EC2 file exists — did it run?": yes, it ran and
+#     found 0. Suppression removes the file; the manifest removes the ambiguity.
+#
+# The manifest is written only when STRATUSSCAN_RUN_MANIFEST points at a file
+# (set by the --run-all orchestrator per exporter subprocess). Interactive
+# single exports get suppression but no manifest — their console message
+# ("No data found — export skipped") is the human-facing equivalent.
+
+# Returned by save_* when an empty export is intentionally suppressed. Truthy
+# so the universal exporter idiom `if output_path: log_success` does NOT fall
+# through to a misleading "save failed" error across the 100+ exporters.
+EMPTY_EXPORT_SENTINEL = "(no data found — export skipped)"
+
+
+def skip_empty_exports_enabled() -> bool:
+    """True when empty results should not produce a spreadsheet (default: on)."""
+    return bool(config_value("skip_empty_exports", default=True, section="output_settings"))
+
+
+def _record_run_manifest(
+    filename: str,
+    rows: int,
+    status: str,
+    file_location: Optional[str],
+    sheets: Optional[dict[str, int]] = None,
+) -> None:
+    """
+    Append one record to the per-run manifest if STRATUSSCAN_RUN_MANIFEST is set.
+
+    Best-effort: any failure here is logged at debug and swallowed — recording
+    a manifest line must never break an export. Account/exporter/region context
+    is read from env vars the orchestrator injects into each subprocess.
+
+    Args:
+        filename: The export filename (basename used as the resource hint).
+        rows: Total asset/row count across all sheets.
+        status: "written" or "empty".
+        file_location: Final delivered location (local path or s3:// URI), or None.
+        sheets: Optional per-sheet row counts.
+    """
+    manifest_path = os.environ.get("STRATUSSCAN_RUN_MANIFEST", "").strip()
+    if not manifest_path:
+        return
+
+    try:
+        record = {
+            "timestamp": datetime.datetime.now().isoformat(timespec="seconds"),
+            "exporter": os.environ.get("STRATUSSCAN_CURRENT_EXPORTER", "").strip() or None,
+            "resource": os.path.basename(filename),
+            "account_id": os.environ.get("STRATUSSCAN_ACCOUNT_ID", "").strip() or None,
+            "account_name": os.environ.get("STRATUSSCAN_ACCOUNT_NAME", "").strip() or None,
+            "regions": os.environ.get("STRATUSSCAN_REGIONS", "").strip() or None,
+            "rows": rows,
+            "status": status,
+            "file": file_location,
+            "sheets": sheets or None,
+        }
+        # Append-only JSONL; concurrent appends are avoided because exporters
+        # run sequentially, but a single write() of one line is atomic enough.
+        with open(manifest_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+    except Exception as e:  # noqa: BLE001
+        logging.getLogger("stratusscan").debug("Run-manifest record failed: %s", e)
+
+
+def _maybe_skip_empty(
+    filename: str, rows: int, sheets: Optional[dict[str, int]] = None
+) -> Optional[str]:
+    """
+    Decide whether an export with ``rows`` total rows should be suppressed.
+
+    Returns the EMPTY_EXPORT_SENTINEL (and records an "empty" manifest line) when
+    there is no data and suppression is enabled; otherwise None (caller proceeds
+    to write). Centralises the empty-handling so every save path behaves alike.
+    """
+    if rows == 0 and skip_empty_exports_enabled():
+        logger.info("No data for %s — empty export skipped", os.path.basename(filename))
+        _record_run_manifest(filename, 0, "empty", None, sheets)
+        return EMPTY_EXPORT_SENTINEL
+    return None
+
+
+def _finalize_export(
+    local_path: str, rows: int, sheets: Optional[dict[str, int]] = None
+) -> str:
+    """
+    Common tail for every successful save: deliver the file (local or S3) and
+    record a "written" manifest line. Returns the final location (local path or
+    ``s3://`` URI).
+    """
+    final = deliver_output(local_path)
+    _record_run_manifest(local_path, rows, "written", final, sheets)
+    return final
+
+
+def read_run_manifest(manifest_path: str) -> list[dict[str, Any]]:
+    """
+    Read a per-run manifest (JSONL) into a list of records.
+
+    Malformed lines are skipped. Returns an empty list if the file is missing.
+    """
+    records: list[dict[str, Any]] = []
+    if not manifest_path or not os.path.exists(manifest_path):
+        return records
+    try:
+        with open(manifest_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError as e:
+        logging.getLogger("stratusscan").warning("Could not read run manifest %s: %s", manifest_path, e)
+    return records
 
 
 def detect_default_format() -> str:

--- a/utils.py
+++ b/utils.py
@@ -966,7 +966,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             os.makedirs(os.path.dirname(output_path), exist_ok=True)
             df.to_csv(output_path, index=False)
             logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-            return str(output_path)
+            return deliver_output(str(output_path))
 
         # --- xlsx path ---
         # Ensure the output directory exists
@@ -988,7 +988,7 @@ def save_dataframe_to_excel(df, filename: str, sheet_name: str = "Data", auto_ad
             df.to_excel(output_path, sheet_name=sheet_name, index=False)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return str(output_path)
+        return deliver_output(str(output_path))
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
@@ -1042,17 +1042,16 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     base_stem = base_stem[: -len(ext)]
                     break
 
-            first_path: Optional[str] = None
+            delivered: list[str] = []
             for sheet_name, df in dataframes_dict.items():
                 slug = _re.sub(r'[^a-z0-9]+', '-', sheet_name.lower()).strip('-')
                 csv_filename = f"{base_stem}-{slug}.csv"
                 csv_path = output_dir / csv_filename
                 df.to_csv(csv_path, index=False)
                 logger.info(_scrub_log(f"Data successfully exported to: {csv_path}"))
-                if first_path is None:
-                    first_path = str(csv_path)
+                delivered.append(deliver_output(str(csv_path)))
 
-            return first_path
+            return delivered[0] if delivered else None
 
         # --- xlsx path ---
         output_path = get_output_filepath(filename)
@@ -1084,11 +1083,272 @@ def save_multiple_dataframes_to_excel(dataframes_dict: dict[str, Any], filename:
                     _adjust_column_widths(writer.sheets[sheet_name], df)
 
         logger.info(_scrub_log(f"Data successfully exported to: {output_path}"))
-        return str(output_path)
+        return deliver_output(str(output_path))
 
     except Exception as e:
         logger.error(f"Error saving file: {e}")
         return None
+
+
+# ---------------------------------------------------------------------------
+# Output delivery — S3 upload (Issue #175)
+# ---------------------------------------------------------------------------
+#
+# Two delivery destinations are supported via the ``output_settings`` config
+# block (or the ``STRATUSSCAN_S3_BUCKET`` env var for headless/CI runs):
+#
+#   * ``local`` (default) — files stay in ``output/`` exactly as before.
+#   * ``s3``            — files are written to ``output/`` first, uploaded to
+#                          the configured bucket, then the local copy is deleted
+#                          on a successful upload. On failure the local file is
+#                          retained as a fallback and the local path is returned.
+#
+# Scanning stays read-only everywhere; the only write any of this performs is a
+# write-only ``PutObject`` to the one designated bucket.
+
+
+def resolve_s3_destination() -> dict[str, Any]:
+    """
+    Resolve the effective output destination from config + environment.
+
+    The ``STRATUSSCAN_S3_BUCKET`` env var is the headless/CI hook: when set it
+    forces S3 delivery regardless of the config ``destination`` value, so a
+    scheduled runner can route output to S3 without a committed config.json.
+    ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix the same way.
+
+    Returns:
+        dict: ``{"enabled": bool, "bucket": str, "prefix": str}``.
+              ``enabled`` is True only when S3 delivery is active AND a bucket
+              is known.
+    """
+    settings = config_value("s3", default={}, section="output_settings") or {}
+    destination = config_value("destination", default="local", section="output_settings")
+
+    env_bucket = os.environ.get("STRATUSSCAN_S3_BUCKET", "").strip()
+    env_prefix = os.environ.get("STRATUSSCAN_S3_PREFIX", "").strip()
+
+    bucket = env_bucket or (settings.get("bucket", "") or "").strip()
+    prefix = env_prefix or settings.get("prefix", "stratusscan/")
+
+    # S3 is active if the env var forced it OR config selected it.
+    selected = bool(env_bucket) or str(destination).lower() == "s3"
+
+    return {
+        "enabled": bool(selected and bucket),
+        "bucket": bucket,
+        "prefix": prefix,
+    }
+
+
+def _s3_bootstrap_region() -> str:
+    """
+    Pick a region for the initial bucket-location lookup and as the upload
+    fallback. Order: STRATUSSCAN_REGIONS → config default_regions → us-east-1.
+
+    Using an operating region (rather than hardcoding us-east-1) keeps the
+    partition correct so GovCloud buckets resolve against a GovCloud endpoint.
+    """
+    env_regions = os.environ.get("STRATUSSCAN_REGIONS", "").strip()
+    if env_regions:
+        first = env_regions.split(",")[0].strip()
+        if first:
+            return first
+
+    defaults = config_value("default_regions", default=[]) or []
+    if defaults:
+        return defaults[0]
+
+    return "us-east-1"
+
+
+def _resolve_bucket_region(bucket: str, bootstrap_region: str) -> Optional[str]:
+    """
+    Return the region a bucket lives in via ``GetBucketLocation``.
+
+    ``LocationConstraint`` is ``None``/empty for us-east-1 (AWS quirk); map that
+    back to ``us-east-1``. Returns None if the lookup fails (caller falls back
+    to the bootstrap region).
+    """
+    try:
+        client = get_boto3_client("s3", bootstrap_region)
+        loc = client.get_bucket_location(Bucket=bucket).get("LocationConstraint")
+        return loc or "us-east-1"
+    except Exception as e:
+        logging.getLogger("stratusscan").debug(
+            "GetBucketLocation failed for bucket '%s' from %s: %s", bucket, bootstrap_region, e
+        )
+        return None
+
+
+def _build_s3_key(prefix: str, local_path: str) -> str:
+    """Join a prefix and a file's basename into an S3 key (single '/' separators)."""
+    name = os.path.basename(local_path)
+    prefix = (prefix or "").lstrip("/")
+    if prefix and not prefix.endswith("/"):
+        prefix += "/"
+    return f"{prefix}{name}"
+
+
+def upload_to_s3(
+    local_path: str,
+    bucket: str,
+    prefix: str = "stratusscan/",
+    region: Optional[str] = None,
+) -> Optional[str]:
+    """
+    Upload a local file to S3 and delete the local copy on success.
+
+    Uses :func:`get_boto3_client` so the upload inherits retry/FIPS behaviour
+    (GovCloud buckets get a FIPS endpoint automatically). The local file is
+    removed only after a successful upload; on any failure it is left in place
+    as a fallback.
+
+    Args:
+        local_path: Path to the file to upload.
+        bucket: Destination S3 bucket name.
+        prefix: Key prefix within the bucket.
+        region: Bucket region. If None, resolved via GetBucketLocation with a
+                bootstrap-region fallback.
+
+    Returns:
+        str: The ``s3://bucket/key`` URI on success, or None on failure.
+    """
+    log = logging.getLogger("stratusscan")
+
+    if not os.path.exists(local_path):
+        log.error("upload_to_s3: local file does not exist: %s", local_path)
+        return None
+    if not bucket:
+        log.error("upload_to_s3: no bucket configured; cannot upload %s", local_path)
+        return None
+
+    bootstrap = _s3_bootstrap_region()
+    if region is None:
+        region = _resolve_bucket_region(bucket, bootstrap) or bootstrap
+
+    key = _build_s3_key(prefix, local_path)
+    try:
+        client = get_boto3_client("s3", region)
+        client.upload_file(local_path, bucket, key)
+    except Exception as e:
+        log.error("S3 upload failed for %s -> s3://%s/%s: %s", local_path, bucket, key, e)
+        log.error("Local file retained at: %s", local_path)
+        return None
+
+    uri = f"s3://{bucket}/{key}"
+    log.info("Uploaded to %s", uri)
+
+    try:
+        os.remove(local_path)
+    except OSError as e:
+        # Upload succeeded — a stranded local copy is non-fatal, just noisy.
+        log.warning("Uploaded to S3 but could not delete local copy %s: %s", local_path, e)
+
+    return uri
+
+
+def deliver_output(local_path: str) -> str:
+    """
+    Post-save delivery hook: route a freshly-saved file to its destination.
+
+    Called by the ``save_*`` helpers after a file is written locally. If S3
+    delivery is active and an upload succeeds, returns the ``s3://`` URI (the
+    local copy is gone). Otherwise — local destination, no bucket, or a failed
+    upload — returns the original local path unchanged.
+
+    Args:
+        local_path: Path to the file just written to ``output/``.
+
+    Returns:
+        str: The S3 URI when uploaded, else the local path.
+    """
+    dest = resolve_s3_destination()
+    if not dest["enabled"]:
+        return local_path
+
+    uri = upload_to_s3(local_path, dest["bucket"], dest["prefix"])
+    return uri if uri else local_path
+
+
+def test_s3_connectivity(
+    bucket: str,
+    prefix: str = "stratusscan/",
+    region: Optional[str] = None,
+) -> dict[str, Any]:
+    """
+    Run a full write roundtrip against a bucket and report which step failed.
+
+    Steps: ``HeadBucket`` → ``PutObject`` (probe file) → ``DeleteObject``
+    (cleanup). S3 permissions are notoriously fiddly, so each step's outcome is
+    captured individually with the verbatim boto3 error — no generic "failed"
+    messages. This is library code: it returns a structured result and never
+    prints; the CLI layer renders it.
+
+    Args:
+        bucket: Bucket to test.
+        prefix: Key prefix the probe object is written under.
+        region: Bucket region (resolved via GetBucketLocation if None).
+
+    Returns:
+        dict: ``{"ok": bool, "bucket": str, "region": str|None, "key": str,
+                 "steps": [{"step", "ok", "error"}], "failed_step": str|None}``
+    """
+    result: dict[str, Any] = {
+        "ok": False,
+        "bucket": bucket,
+        "region": region,
+        "key": None,
+        "steps": [],
+        "failed_step": None,
+    }
+
+    if not bucket:
+        result["steps"].append(
+            {"step": "config", "ok": False, "error": "No bucket configured."}
+        )
+        result["failed_step"] = "config"
+        return result
+
+    bootstrap = _s3_bootstrap_region()
+    if region is None:
+        region = _resolve_bucket_region(bucket, bootstrap) or bootstrap
+    result["region"] = region
+
+    key = _build_s3_key(prefix, "stratusscan-connectivity-test.txt")
+    result["key"] = key
+
+    def _run(step_name, fn) -> bool:
+        try:
+            fn()
+            result["steps"].append({"step": step_name, "ok": True, "error": None})
+            return True
+        except Exception as e:
+            result["steps"].append({"step": step_name, "ok": False, "error": str(e)})
+            result["failed_step"] = step_name
+            return False
+
+    try:
+        client = get_boto3_client("s3", region)
+    except Exception as e:
+        result["steps"].append({"step": "client", "ok": False, "error": str(e)})
+        result["failed_step"] = "client"
+        return result
+
+    if not _run("HeadBucket", lambda: client.head_bucket(Bucket=bucket)):
+        return result
+    if not _run(
+        "PutObject",
+        lambda: client.put_object(
+            Bucket=bucket, Key=key, Body=b"stratusscan connectivity test"
+        ),
+    ):
+        return result
+    if not _run("DeleteObject", lambda: client.delete_object(Bucket=bucket, Key=key)):
+        return result
+
+    result["ok"] = True
+    return result
+
 
 def detect_default_format() -> str:
     """
@@ -1189,7 +1449,7 @@ def aws_error_handler(
 
     Example:
         @aws_error_handler("Collecting IAM users", default_return=[])
-        def collect_iam_users() -> List[Dict[str, Any]]:
+        def collect_iam_users() -> list[dict[str, Any]]:
             iam = get_boto3_client('iam')
             users = []
             for user in iam.list_users()['Users']:

--- a/utils.py
+++ b/utils.py
@@ -1129,10 +1129,14 @@ def resolve_s3_destination() -> dict[str, Any]:
     """
     Resolve the effective output destination from config + environment.
 
-    The ``STRATUSSCAN_S3_BUCKET`` env var is the headless/CI hook: when set it
-    forces S3 delivery regardless of the config ``destination`` value, so a
-    scheduled runner can route output to S3 without a committed config.json.
-    ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix the same way.
+    Resolution priority for the destination:
+      1. ``STRATUSSCAN_OUTPUT_DESTINATION`` env (``local``/``s3``) — authoritative;
+         this is how the ``--output`` flag forces a destination for the headless
+         orchestrator and every exporter subprocess it launches. ``local`` here
+         wins even if a bucket is configured.
+      2. ``STRATUSSCAN_S3_BUCKET`` env set — implies S3 (CI hook; no config.json
+         needed). ``STRATUSSCAN_S3_PREFIX`` optionally overrides the prefix.
+      3. config ``output_settings.destination``.
 
     Returns:
         dict: ``{"enabled": bool, "bucket": str, "prefix": str}``.
@@ -1140,16 +1144,21 @@ def resolve_s3_destination() -> dict[str, Any]:
               is known.
     """
     settings = config_value("s3", default={}, section="output_settings") or {}
-    destination = config_value("destination", default="local", section="output_settings")
+    config_destination = str(config_value("destination", default="local", section="output_settings")).lower()
 
+    env_dest = os.environ.get("STRATUSSCAN_OUTPUT_DESTINATION", "").strip().lower()
     env_bucket = os.environ.get("STRATUSSCAN_S3_BUCKET", "").strip()
     env_prefix = os.environ.get("STRATUSSCAN_S3_PREFIX", "").strip()
 
     bucket = env_bucket or (settings.get("bucket", "") or "").strip()
     prefix = env_prefix or settings.get("prefix", "stratusscan/")
 
-    # S3 is active if the env var forced it OR config selected it.
-    selected = bool(env_bucket) or str(destination).lower() == "s3"
+    if env_dest in ("local", "s3"):
+        # Explicit flag override wins over everything (including a set bucket).
+        selected = env_dest == "s3"
+    else:
+        # Otherwise a set bucket env, or config, selects S3.
+        selected = bool(env_bucket) or config_destination == "s3"
 
     return {
         "enabled": bool(selected and bucket),
@@ -1497,6 +1506,103 @@ def read_run_manifest(manifest_path: str) -> list[dict[str, Any]]:
     except OSError as e:
         logging.getLogger("stratusscan").warning("Could not read run manifest %s: %s", manifest_path, e)
     return records
+
+
+# Run-report status vocabulary (one per exporter attempted in a --run-all run).
+RUN_STATUS_OK = "OK"                # exited clean, wrote at least one populated export
+RUN_STATUS_EMPTY = "EMPTY"          # exited clean, ran, found 0 assets (no file written)
+RUN_STATUS_NO_OUTPUT = "NO OUTPUT"  # exited clean but saved nothing (e.g. service N/A in partition)
+RUN_STATUS_FAILED = "FAILED"        # non-zero exit / crash / timeout
+
+
+def _format_sheets(sheets: Optional[dict[str, int]]) -> str:
+    """Render per-sheet counts as 'Sheet:rows, ...' for the report."""
+    if not sheets:
+        return ""
+    return ", ".join(f"{name}:{count}" for name, count in sheets.items())
+
+
+def build_run_report_dataframe(
+    executor_results: list[dict[str, Any]],
+    manifest_records: list[dict[str, Any]],
+):
+    """
+    Merge per-script execution results with per-save manifest records into a
+    single run-report DataFrame — the authoritative "what ran / what was found"
+    artifact for an unattended audit.
+
+    Each row is one exporter attempted, with a status that distinguishes the
+    four outcomes auditors care about: OK (data found), EMPTY (ran, 0 assets),
+    NO OUTPUT (ran clean but nothing to export — e.g. service not in partition),
+    and FAILED. The asset count is recorded even when no spreadsheet exists,
+    which is precisely what kills the "no EC2 file, did it run?" false positive.
+
+    Args:
+        executor_results: list of dicts with at least ``script``, ``success``,
+            ``return_code``, ``duration_seconds`` (ExecutionResult flattened).
+        manifest_records: records from :func:`read_run_manifest`.
+
+    Returns:
+        pandas.DataFrame sorted by exporter name.
+    """
+    import pandas as pd
+
+    # Index manifest records by exporter filename.
+    by_exporter: dict[str, list[dict[str, Any]]] = {}
+    for rec in manifest_records:
+        key = rec.get("exporter") or rec.get("resource") or ""
+        by_exporter.setdefault(key, []).append(rec)
+
+    rows: list[dict[str, Any]] = []
+    for res in executor_results:
+        exporter = res.get("script", "")
+        recs = by_exporter.get(exporter, [])
+        written = [r for r in recs if r.get("status") == "written"]
+        assets = sum(int(r.get("rows") or 0) for r in recs)
+
+        if not res.get("success", False):
+            status = RUN_STATUS_FAILED
+        elif written:
+            status = RUN_STATUS_OK
+        elif recs:  # only empty records
+            status = RUN_STATUS_EMPTY
+        else:
+            status = RUN_STATUS_NO_OUTPUT
+
+        file_loc = ""
+        if written:
+            file_loc = written[0].get("file") or ""
+
+        sheets_str = ""
+        for r in recs:
+            if r.get("sheets"):
+                sheets_str = _format_sheets(r.get("sheets"))
+                break
+
+        regions = ""
+        if recs and recs[0].get("regions"):
+            regions = recs[0]["regions"]
+
+        detail = ""
+        if status == RUN_STATUS_FAILED:
+            detail = (res.get("error_message") or f"exit code {res.get('return_code')}").strip()
+
+        rows.append({
+            "Exporter": exporter,
+            "Status": status,
+            "Assets": assets,
+            "Output File": file_loc,
+            "Sheets": sheets_str,
+            "Regions": regions,
+            "Duration (s)": round(float(res.get("duration_seconds") or 0), 1),
+            "Detail": detail,
+        })
+
+    columns = ["Exporter", "Status", "Assets", "Output File", "Sheets", "Regions", "Duration (s)", "Detail"]
+    df = pd.DataFrame(rows, columns=columns)
+    if not df.empty:
+        df = df.sort_values("Exporter").reset_index(drop=True)
+    return df
 
 
 def detect_default_format() -> str:

--- a/utils.py
+++ b/utils.py
@@ -586,7 +586,7 @@ def log_error(error_message: str, error_obj: Optional[Exception] = None) -> None
     if error_obj:
         current_logger.error(_scrub_log(f"{error_message}: {str(error_obj)}"))
         # Log stack trace for debugging
-        current_logger.debug(f"Exception details: {error_obj}", exc_info=True)
+        current_logger.debug(_scrub_log(f"Exception details: {error_obj}"), exc_info=True)
     else:
         current_logger.error(_scrub_log(error_message))
 
@@ -977,6 +977,60 @@ def get_output_dir() -> Path:
     output_dir.mkdir(parents=True, exist_ok=True)
     return output_dir
 
+# Characters that can redirect a path or corrupt a filename: path separators,
+# Windows-reserved punctuation, and control characters (including NUL).
+_UNSAFE_NAME_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f]')
+
+def sanitize_filename_component(value: object) -> str:
+    """
+    Reduce an untrusted value to a safe single filename component (CWE-73).
+
+    Strips — rather than substitutes — path separators, control characters, and
+    parent-directory markers, so ordinary names (letters, digits, spaces, dots,
+    hyphens, underscores) are returned byte-identical and existing export
+    filenames are unaffected.
+
+    Args:
+        value: The untrusted value (e.g. an account name from config.json)
+
+    Returns:
+        str: The value with path-altering characters removed
+    """
+    text = _UNSAFE_NAME_CHARS.sub("", str(value))
+    # Remove parent-directory markers, repeating until stable so that crafted
+    # sequences like '....' cannot reconstitute a '..' after a single pass.
+    while ".." in text:
+        text = text.replace("..", "")
+    # A leading dot would hide the file; a trailing dot/space is stripped by
+    # some filesystems and would let two distinct names collide.
+    return text.strip(" .")
+
+def contained_path(base_dir: "str | Path", filename: str) -> Path:
+    """
+    Resolve ``filename`` to a direct child of ``base_dir``, refusing escapes.
+
+    Containment (CWE-73): reduce to a bare filename and confirm it resolves to a
+    direct child of the base directory, so a crafted name containing path
+    separators or '..' cannot escape it. Ordinary bare filenames pass through
+    unchanged.
+
+    Args:
+        base_dir: The directory the file must live directly inside
+        filename: The candidate filename
+
+    Returns:
+        Path: ``base_dir`` joined with the validated bare filename
+
+    Raises:
+        ValueError: If the name would resolve outside ``base_dir``.
+    """
+    base = Path(base_dir).resolve()
+    safe_name = os.path.basename(str(filename))
+    resolved = (base / safe_name).resolve()
+    if safe_name in ("", ".", "..") or resolved.parent != base:
+        raise ValueError(f"Refusing path outside {base}: {filename!r}")
+    return base / safe_name
+
 def get_output_filepath(filename: str) -> Path:
     """
     Get the full path for a file in the output directory.
@@ -990,16 +1044,7 @@ def get_output_filepath(filename: str) -> Path:
     Raises:
         ValueError: If the name would resolve outside the output directory.
     """
-    output_dir = get_output_dir().resolve()
-    # Containment (CWE-73): reduce to a bare filename and confirm it resolves to
-    # a direct child of the output directory, so a crafted name containing path
-    # separators or '..' cannot escape it. Standard export filenames are already
-    # bare and pass through unchanged.
-    safe_name = os.path.basename(filename)
-    resolved = (output_dir / safe_name).resolve()
-    if safe_name in ("", ".", "..") or resolved.parent != output_dir:
-        raise ValueError(f"Refusing output path outside output directory: {filename!r}")
-    return output_dir / safe_name
+    return contained_path(get_output_dir(), filename)
 
 def create_export_filename(
     account_name: str,
@@ -1030,6 +1075,13 @@ def create_export_filename(
     # Get current date if not provided
     if not current_date:
         current_date = datetime.datetime.now().strftime("%m.%d.%Y")
+
+    # Sanitize caller-supplied components (CWE-73): account_name comes from the
+    # account_mappings in config.json, so a crafted entry must not be able to
+    # steer the export out of the output directory. Ordinary names are unchanged.
+    account_name = sanitize_filename_component(account_name)
+    resource_type = sanitize_filename_component(resource_type)
+    suffix = sanitize_filename_component(suffix)
 
     # Build the base filename
     if suffix:
@@ -2655,9 +2707,13 @@ class ProgressCheckpoint:
         self.checkpoint_dir = Path(checkpoint_dir)
         self.checkpoint_dir.mkdir(exist_ok=True)
 
-        # Checkpoint file path
+        # Checkpoint file path — operation_name is caller-supplied, so sanitize
+        # the component and confirm containment in checkpoint_dir (CWE-73).
         timestamp = datetime.datetime.now().strftime("%Y%m%d")
-        self.checkpoint_file = self.checkpoint_dir / f"{operation_name}_{timestamp}.json"
+        safe_operation = sanitize_filename_component(operation_name)
+        self.checkpoint_file = contained_path(
+            self.checkpoint_dir, f"{safe_operation}_{timestamp}.json"
+        )
 
         # Load existing checkpoint if available
         self.checkpoint_data = self._load()

--- a/utils.py
+++ b/utils.py
@@ -330,6 +330,96 @@ def prompt_menu(
         print(MSG_INVALID_SELECTION)
 
 
+def prompt_multiselect(
+    title: str,
+    options: list[str],
+    all_label: Optional[str] = None,
+    allow_back: bool = True,
+    allow_exit: bool = True,
+    allow_quit: bool = True,
+) -> list[int]:
+    """
+    Present a numbered multi-select menu and return the chosen option indices.
+
+    Numbers are entered space-separated (e.g. ``1 3 5``). When *all_label* is
+    provided it is shown as the first numbered row; selecting it returns every
+    option — this replaces the old magic ``0 = All`` convention so every row is
+    a real, consistently-numbered choice. Navigation follows the single-voice
+    standard: ``b``/``x``/``q`` surface as BackSignal / ExitToMainSignal /
+    QuitSignal.
+
+    Args:
+        title: Menu title displayed above the border.
+        options: Selectable option labels (shown after the optional All row).
+        all_label: If given, adds a leading "select all" row with this label.
+        allow_back / allow_exit / allow_quit: Which navigation keys to offer.
+
+    Returns:
+        list[int]: 1-based indices into *options* (never empty).
+
+    Raises:
+        BackSignal / ExitToMainSignal / QuitSignal per the standard.
+    """
+    if is_auto_run():
+        return list(range(1, len(options) + 1))
+
+    has_all = all_label is not None
+    while True:
+        print(f"\n{title}")
+        print("=" * 64)
+        rows = ([all_label] if has_all else []) + list(options)
+        for i, row in enumerate(rows, 1):
+            print(f"  {i:2d}. {row}")
+        print("-" * 64)
+        if allow_back or allow_exit or allow_quit:
+            print(_nav_footer(allow_back, allow_exit, allow_quit))
+        print("=" * 64)
+
+        try:
+            raw = input(
+                "Enter number(s) separated by spaces (e.g. 1  or  1 3 5): "
+            ).strip().lower()
+        except KeyboardInterrupt:
+            print()
+            if allow_quit:
+                raise QuitSignal from None
+            continue
+
+        if allow_back and raw == 'b':
+            raise BackSignal
+        if allow_exit and raw == 'x':
+            raise ExitToMainSignal
+        if allow_quit and raw == 'q':
+            raise QuitSignal
+
+        tokens = raw.split()
+        if not tokens or not all(t.isdigit() for t in tokens):
+            print(MSG_INVALID_SELECTION)
+            continue
+
+        picks = [int(t) for t in tokens]
+        if any(p < 1 or p > len(rows) for p in picks):
+            print(MSG_INVALID_SELECTION)
+            continue
+
+        # The "All" row (row 1, when present) short-circuits to every option.
+        if has_all and 1 in picks:
+            return list(range(1, len(options) + 1))
+
+        # De-dupe, preserve order, and offset past the All row.
+        offset = 1 if has_all else 0
+        seen: set = set()
+        result: list[int] = []
+        for p in picks:
+            option_index = p - offset
+            if option_index >= 1 and option_index not in seen:
+                seen.add(option_index)
+                result.append(option_index)
+        if result:
+            return result
+        print(MSG_INVALID_SELECTION)
+
+
 def prompt_region_selection(
     service_name: Optional[str] = None,
 ) -> Union[list[str], str]:

--- a/utils.py
+++ b/utils.py
@@ -1605,6 +1605,116 @@ def build_run_report_dataframe(
     return df
 
 
+# ---------------------------------------------------------------------------
+# Organization-wide scanning (--org-scan): account enumeration + roll-up
+# ---------------------------------------------------------------------------
+#
+# The headless org audit runs from one account (the Audit account), enumerates
+# every active account in the AWS Organization, assumes a uniformly-named
+# read-only scan role in each, and runs the full exporter set per account. This
+# matches the StackSet model where one role name exists org-wide.
+
+# Org-account scan outcomes for the roll-up summary.
+ACCOUNT_STATUS_SCANNED = "SCANNED"        # role assumed, exporters ran
+ACCOUNT_STATUS_ROLE_FAILED = "ROLE FAILED"  # could not assume the scan role — skipped
+
+
+def list_organization_accounts(active_only: bool = True) -> list[dict[str, str]]:
+    """
+    Enumerate accounts in the AWS Organization via ``organizations:ListAccounts``.
+
+    Runs from the management or a delegated-admin account. Library code: returns
+    structured data and never prints.
+
+    Args:
+        active_only: When True (default), only ``ACTIVE`` accounts are returned
+            (SUSPENDED / PENDING_CLOSURE accounts are skipped).
+
+    Returns:
+        list of ``{"id", "name", "email", "status"}`` dicts.
+
+    Raises:
+        Propagates botocore errors (e.g. AccessDenied when the caller lacks
+        Organizations read access) so the caller can report them verbatim.
+    """
+    client = get_boto3_client("organizations")
+    accounts: list[dict[str, str]] = []
+    paginator = client.get_paginator("list_accounts")
+    for page in paginator.paginate():
+        for a in page.get("Accounts", []):
+            status = a.get("Status", "")
+            if active_only and status != "ACTIVE":
+                continue
+            accounts.append({
+                "id": a.get("Id", ""),
+                "name": a.get("Name", ""),
+                "email": a.get("Email", ""),
+                "status": status,
+            })
+    return accounts
+
+
+def verify_assume_role(role_arn: str, region_name: Optional[str] = None) -> tuple[bool, Optional[str]]:
+    """
+    Pre-flight an STS AssumeRole so a non-assumable account can be skipped before
+    launching 100+ doomed exporter subprocesses.
+
+    Args:
+        role_arn: The scan role ARN to assume.
+        region_name: Optional region (drives FIPS endpoint selection in GovCloud).
+
+    Returns:
+        ``(True, None)`` if the role is assumable, else ``(False, error_string)``
+        with the verbatim error for the run report.
+    """
+    try:
+        sts = get_boto3_client("sts", region_name, role_arn=role_arn)
+        sts.get_caller_identity()
+        return True, None
+    except Exception as e:  # noqa: BLE001
+        return False, str(e)
+
+
+def build_org_summary_dataframe(account_summaries: list[dict[str, Any]]):
+    """
+    Roll up per-account audit outcomes into one org-level summary DataFrame —
+    one row per account, the top-level index over the per-account run reports.
+
+    Args:
+        account_summaries: list of dicts with keys ``account_id``,
+            ``account_name``, ``status`` (ACCOUNT_STATUS_*), ``exporters``,
+            ``ok``, ``empty``, ``no_output``, ``failed``, ``total_assets``,
+            ``report`` (delivered location or ""), and optional ``detail``.
+
+    Returns:
+        pandas.DataFrame sorted by account name.
+    """
+    import pandas as pd
+
+    rows = []
+    for s in account_summaries:
+        rows.append({
+            "Account ID": s.get("account_id", ""),
+            "Account": s.get("account_name", ""),
+            "Status": s.get("status", ""),
+            "Exporters": s.get("exporters", 0),
+            "With Data": s.get("ok", 0),
+            "Empty": s.get("empty", 0),
+            "No Output": s.get("no_output", 0),
+            "Failed": s.get("failed", 0),
+            "Total Assets": s.get("total_assets", 0),
+            "Report": s.get("report", ""),
+            "Detail": s.get("detail", ""),
+        })
+
+    columns = ["Account ID", "Account", "Status", "Exporters", "With Data",
+               "Empty", "No Output", "Failed", "Total Assets", "Report", "Detail"]
+    df = pd.DataFrame(rows, columns=columns)
+    if not df.empty:
+        df = df.sort_values("Account").reset_index(drop=True)
+    return df
+
+
 def detect_default_format() -> str:
     """
     Detect the default export format based on available dependencies.

--- a/utils.py
+++ b/utils.py
@@ -88,6 +88,41 @@ class QuitSignal(Exception):
     """Raised when the user enters 'q' to quit."""
 
 
+# ---------------------------------------------------------------------------
+# Interaction constants — the single-voice standard for every interactive prompt
+# ---------------------------------------------------------------------------
+
+#: Status glyphs. Green check / red x is the tool-wide standard — use these
+#: instead of ✓/✗/ERROR: so status output reads the same everywhere.
+GLYPH_OK = "✅"
+GLYPH_FAIL = "❌"
+
+#: The single invalid-input message for every menu / selection prompt.
+MSG_INVALID_SELECTION = "Invalid selection. Please try again."
+
+
+def _nav_footer(
+    allow_back: bool = True,
+    allow_exit: bool = True,
+    allow_quit: bool = True,
+) -> str:
+    """
+    Build the canonical navigation footer shown beneath interactive menus.
+
+    Returns a single line like ``  b = back  |  x = main menu  |  q = quit``,
+    including only the keys that are enabled. The wording and punctuation here
+    are the single-voice standard — every menu footer routes through this.
+    """
+    parts = []
+    if allow_back:
+        parts.append("b = back")
+    if allow_exit:
+        parts.append("x = main menu")
+    if allow_quit:
+        parts.append("q = quit")
+    return "  " + "  |  ".join(parts)
+
+
 def get_version() -> str:
     """Return the installed package version, or 'dev' if not installed."""
     try:
@@ -231,22 +266,28 @@ def prompt_menu(
     options: list[str],
     allow_back: bool = True,
     allow_exit: bool = True,
+    allow_quit: bool = True,
 ) -> int:
     """
     Display a bordered numbered menu and return the user's choice.
+
+    Navigation follows the single-voice standard: ``b`` = back, ``x`` = main
+    menu, ``q`` = quit — surfaced as BackSignal / ExitToMainSignal / QuitSignal.
 
     Args:
         title: Menu title displayed above the border
         options: List of option strings (displayed as 1..N)
         allow_back: If True, show and accept 'b' to go back (default: True)
-        allow_exit: If True, show and accept 'x' to exit (default: True)
+        allow_exit: If True, show and accept 'x' for the main menu (default: True)
+        allow_quit: If True, show and accept 'q' to quit (default: True)
 
     Returns:
         int 1..N if the user picks a numbered option.
 
     Raises:
         BackSignal: if the user enters 'b' (and allow_back is True).
-        QuitSignal: if the user enters 'x' (and allow_exit is True) or
+        ExitToMainSignal: if the user enters 'x' (and allow_exit is True).
+        QuitSignal: if the user enters 'q' (and allow_quit is True) or
             presses Ctrl-C.
     """
     if is_auto_run():
@@ -257,13 +298,8 @@ def prompt_menu(
     for i, opt in enumerate(options, 1):
         print(f"  {i}. {opt}")
     print("-" * 64)
-    footer_parts = []
-    if allow_back:
-        footer_parts.append("b. Back")
-    if allow_exit:
-        footer_parts.append("x. Exit")
-    if footer_parts:
-        print("  " + "    ".join(footer_parts))
+    if allow_back or allow_exit or allow_quit:
+        print(_nav_footer(allow_back, allow_exit, allow_quit))
     print("=" * 64)
 
     valid = {str(i) for i in range(1, len(options) + 1)}
@@ -271,13 +307,15 @@ def prompt_menu(
         valid.add("b")
     if allow_exit:
         valid.add("x")
+    if allow_quit:
+        valid.add("q")
 
     while True:
         try:
             choice = input("Enter your choice: ").strip().lower()
         except KeyboardInterrupt:
             print()
-            if allow_exit:
+            if allow_quit:
                 raise QuitSignal from None
             continue
 
@@ -285,9 +323,11 @@ def prompt_menu(
             if choice == 'b':
                 raise BackSignal
             if choice == 'x':
+                raise ExitToMainSignal
+            if choice == 'q':
                 raise QuitSignal
             return int(choice)
-        print("Invalid choice. Please try again.")
+        print(MSG_INVALID_SELECTION)
 
 
 def prompt_region_selection(
@@ -342,7 +382,7 @@ def prompt_region_selection(
             choice = prompt_menu("REGION SELECTION", options)
         except BackSignal:
             return 'back'
-        except QuitSignal:
+        except (ExitToMainSignal, QuitSignal):
             return 'exit'
 
         if choice == 1:
@@ -373,7 +413,7 @@ def prompt_region_selection(
                     for i, r in enumerate(available, 1):
                         print(f"  {i:2d}. {r}")
                 print("=" * 64)
-                print("  b. Back    x. Exit")
+                print(_nav_footer())
                 print("=" * 64)
 
                 try:
@@ -386,7 +426,7 @@ def prompt_region_selection(
 
                 if raw == 'b':
                     break  # back to main region menu
-                if raw == 'x':
+                if raw in ('x', 'q'):
                     return 'exit'
 
                 tokens = raw.split()


### PR DESCRIPTION
StratusScan CLI (AWS) **v0.7.0-beta** — 8 PRs, 21 commits since `v0.6.0-beta`.

This release lands the manual half of unattended audit mode, unifies every interactive surface behind a single interaction contract, and hardens file-path handling.

## Unattended audit mode — the manual half

The pieces needed to run a full audit with nobody at the keyboard:

- **`--run-all`** executes every exporter in one headless pass and writes a spreadsheet run report (#203).
- **`--org-scan`** extends that across every account in an AWS Organization via `--scan-role`, reusing the existing STS cross-account plumbing (#204).
- **S3 delivery** — exports can go straight to a bucket instead of the local `output/` directory, with the local copy removed on success. Configure via `python configure.py` → Output Settings; a least-privilege policy ships in `policies/s3-upload-permissions.json` (#175, #199).
- **Run manifests and empty-export suppression** — each run records what ran, what it found and what failed. An exporter that finds nothing writes no spreadsheet, but the run report still logs it as "ran, 0 assets". On by default (#202).

Empty-export suppression is orthogonal to the v0.6.0 fail-loud contract: genuine collection failures still write a `*-FAILED-*.txt` marker and exit non-zero.

## One interaction voice across the CLI

Five competing prompt dialects had accumulated across the codebase. Every interactive surface — menus, multi-selects, confirmations, and both config wizards — now follows one contract (#252):

- Numbered `1..N` menus, one item per line. No bracketed `[1]`, no lettered `[A]/[E]`, no magic `0 = All`.
- `b` = back, `x` = main menu, `q` = quit, everywhere, via signal-based flow control.
- Two-tier confirmations: an Enter-to-confirm review gate before running exporters, and discrete y/N prompts elsewhere.
- Consistent ✅/❌ status glyphs.

The Cost Management all-in-one menu in particular no longer changes input style between steps — that was a shared bundle driver running a three-step machine with a different convention at each step.

**Three latent bugs surfaced and were fixed in the process:** the Cost bundle silently skipped Compute Optimizer; Smart Scan ran *everything* when `questionary` was absent instead of offering a real plain-text fallback; and the services-in-use exporter ignored the region back/exit signal.

## Path-handling hardening

File paths built from caller-supplied values are now validated against a single containment helper, so a crafted account name in `config.json` cannot steer an export outside its intended directory (CWE-73) (#253, #254).

This also closes a real bug found alongside it: the Smart Scan checklist was written to a bare relative path, landing in the caller's working directory rather than `output/`.

## Also in this release

- Smart Scan now resolves `Amazon CloudWatch Logs` to the CloudWatch exporter instead of misclassifying it as having no exporter (#251).
- Documentation no longer references the abandoned TUI direction (#250).

## Upgrade notes

No breaking changes. Interactive navigation keys are more consistent than before, so muscle memory built on the old per-menu conventions may need a moment — `b` / `x` / `q` now work the same way everywhere.

## Still beta

The API and output format may change before 1.0.0. Remaining v1.0 scope is the **scheduled** runner: one-command deployment of the recurring audit (CloudFormation stack, CodeBuild, EventBridge Scheduler, SNS notification). That is not built — this release covers the cross-account and S3-delivered halves only.

**Requires Python 3.10+.** Runs in a fresh AWS CloudShell session with read-only permissions and no setup beyond `pip install`.
